### PR TITLE
fix(router): export navigation strategies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,3 +4,4 @@ export {PipelineProvider} from './pipeline-provider';
 export {Redirect} from './navigation-commands';
 export {RouteLoader} from './route-loading';
 export {RouterConfiguration} from './router-configuration';
+export {NO_CHANGE, INVOKE_LIFECYCLE, REPLACE} from './navigation-plan';


### PR DESCRIPTION
the replace, invoke lifecycle, and no_change strategies
needed to be exported so that they could be used