### PR TITLE
fix(router): url fragments duplicated on subsequent navigations between routes when using pushState

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -38,6 +38,8 @@ export class Router {
         } else {
           current.href = '#/' + this.baseUrl;
         }
+      } else {
+        current.href = '/' + this.baseUrl;
       }
 
       if (current.href[current.href.length - 1] != '/') {


### PR DESCRIPTION
This PR fixes the following issue:

When pushState is enabled, navigating between routes duplicates/nests url fragments, here's an example:

1. Starting at /
2. Navigate to /route1

Expected:
Link to /route1 in the navigation is still /route1
Link to /route2 in the navigation is still /route2

Actual result:
Link to /route1 is /route1/route1
Link to /route2 is /route2/route2

Subsequent navigations keep nesting under the current location