### PR TITLE
fix(router): link click handler not triggering when clicking on a nested element inside an anchor

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -111,13 +111,20 @@ export class AppRouter extends Router {
   }
 }
 
+function findAnchor(el) {
+  while (el) {
+    if (el.tagName === "A") return el;
+    el = el.parentNode;
+  }
+}
+
 function handleLinkClick(evt) {
   if (!this.isActive) {
     return;
   }
 
-  var target = evt.target;
-  if (target.tagName != 'A') {
+  var target = findAnchor(evt.target);
+  if (!target) {
     return;
   }
 


### PR DESCRIPTION
When an anchor has nested elements, like the following example:

    <a href="/">
        <i class="icon-home"></i>
        <span>Some text</span>
    </a>

When clicking on the inner elements (icon or span), the link is not being handled, and a full page reload happens instead