### PR TITLE
feat(router): add support for named pipelines

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -12,6 +12,10 @@ export class AppRouter extends Router {
     document.addEventListener('click', handleLinkClick.bind(this), true);
   }
 
+  get isRoot() {
+    return true;
+  }
+
   loadUrl(url) {
     return this.createNavigationInstruction(url).
       then(instruction => this.queueInstruction(instruction)).

--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ export {Redirect} from './navigation-commands';
 export {RouteLoader} from './route-loading';
 export {RouterConfiguration} from './router-configuration';
 export {NO_CHANGE, INVOKE_LIFECYCLE, REPLACE} from './navigation-plan';
+export {RouteFilterContainer, createRouteFilterStep} from './route-filters';

--- a/src/navigation-context.js
+++ b/src/navigation-context.js
@@ -8,6 +8,28 @@ export class NavigationContext {
     this.prevInstruction = router.currentInstruction;
   }
 
+  getAllContexts(acc = []) {
+    acc.push(this);
+    if(this.plan) {
+      for (var key in this.plan) {
+        this.plan[key].childNavigationContext && this.plan[key].childNavigationContext.getAllContexts(acc);
+      }
+    }
+    return acc;
+  }
+
+  get nextInstructions() {
+    return this.getAllContexts().map(c => c.nextInstruction).filter(c => c);
+  }
+
+  get currentInstructions() {
+    return this.getAllContexts().map(c => c.currentInstruction).filter(c => c);
+  }
+
+  get prevInstructions() {
+    return this.getAllContexts().map(c => c.prevInstruction).filter(c => c);
+  }
+
   commitChanges(waitToSwap) {
     var next = this.nextInstruction,
         prev = this.prevInstruction,

--- a/src/pipeline-provider.js
+++ b/src/pipeline-provider.js
@@ -10,6 +10,7 @@ import {
   DeactivatePreviousStep,
   ActivateNextStep
 } from './activation';
+import {createRouteFilterStep} from './route-filters';
 
 export class PipelineProvider {
   static inject(){ return [Container]; }
@@ -19,7 +20,8 @@ export class PipelineProvider {
       BuildNavigationPlanStep,
       CanDeactivatePreviousStep, //optional
       LoadRouteStep,
-      ApplyModelBindersStep, //optional
+      createRouteFilterStep('authorize'),
+      createRouteFilterStep('modelbind'),
       CanActivateNextStep, //optional
       //NOTE: app state changes start below - point of no return
       DeactivatePreviousStep, //optional

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -18,10 +18,17 @@ export class Pipeline {
   }
 
   withStep(step) {
-    var run;
+    var run, steps, i, l;
 
     if (typeof step == 'function') {
       run = step;
+    } else if (step.isMultiStep) {
+      steps = step.getSteps();
+      for (i = 0, l = steps.length; i < l; i++) {
+        this.withStep(steps[i]);
+      }
+
+      return this;
     } else {
       run = step.run.bind(step);
     }

--- a/src/route-filters.js
+++ b/src/route-filters.js
@@ -1,0 +1,68 @@
+import {Container} from 'aurelia-dependency-injection';
+
+export class RouteFilterContainer {
+  static inject(){ return [Container]; }
+  constructor(container) {
+    this.container = container;
+    this.filters = { };
+    this.filterCache = { };
+  }
+
+  addStep(name, step, index = -1) {
+    var filter = this.filters[name];
+    if (!filter) {
+      filter = this.filters[name] = [];
+    }
+
+    if (index === -1) {
+      index = filter.length;
+    }
+
+    filter.splice(index, 0, step);
+    this.filterCache = {};
+  }
+
+  getFilterSteps(name) {
+    if (this.filterCache[name]) {
+      return this.filterCache[name];
+    }
+
+    var steps = [];
+    var filter = this.filters[name];
+    if (!filter) {
+      return steps;
+    }
+
+    for (var i = 0, l = filter.length; i < l; i++) {
+      if (typeof filter[i] === 'string') {
+        steps.push(...this.getFilterSteps(filter[i]));
+      } else {
+        steps.push(this.container.get(filter[i]));
+      }
+    }
+
+    return this.filterCache[name] = steps;
+  }
+}
+
+export function createRouteFilterStep(name) {
+  function create(routeFilterContainer) {
+    return new RouteFilterStep(name, routeFilterContainer);
+  };
+  create.inject = function() {
+    return [RouteFilterContainer];
+  };
+  return create;
+}
+
+class RouteFilterStep {
+  constructor(name, routeFilterContainer) {
+    this.name = name;
+    this.routeFilterContainer = routeFilterContainer;
+    this.isMultiStep = true;
+  }
+
+  getSteps() {
+    return this.routeFilterContainer.getFilterSteps(this.name);
+  }
+}

--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -1,7 +1,14 @@
+import {RouteFilterContainer} from './route-filters';
+
 export class RouterConfiguration{
   constructor() {
     this.instructions = [];
     this.options = {};
+    this.pipelineSteps = [];
+  }
+
+  addPipelineStep(name, step) {
+    this.pipelineSteps.push({name, step});
   }
 
   map(route, config) {
@@ -53,7 +60,8 @@ export class RouterConfiguration{
 
   exportToRouter(router) {
     var instructions = this.instructions,
-        i, ii;
+        pipelineSteps = this.pipelineSteps,
+        i, ii, filterContainer;
 
     for (i = 0, ii = instructions.length; i < ii; ++i) {
       instructions[i](router);
@@ -68,6 +76,19 @@ export class RouterConfiguration{
     }
 
     router.options = this.options;
+
+    if (pipelineSteps.length) {
+      // Pipeline steps should only be added at the app router
+      if (!router.isRoot) {
+        throw new Error('Pipeline steps can only be added to the root router');
+      }
+
+      filterContainer = router.container.get(RouteFilterContainer);
+      for (i = 0, ii = pipelineSteps.length; i < ii; ++i) {
+        var {name, step} = pipelineSteps[i];
+        filterContainer.addStep(name, step);
+      }
+    }
   }
 
   configureRoute(router, config, navModel) {

--- a/src/router.js
+++ b/src/router.js
@@ -14,6 +14,10 @@ export class Router {
     this.baseUrl = '';
   }
 
+  get isRoot() {
+    return false;
+  }
+
   registerViewPort(viewPort, name) {
     name = name || 'default';
     this.viewPorts[name] = viewPort;


### PR DESCRIPTION
This adds support for small named pipelines, named
route-filters, which can easily be added at given points
in the pipeline. By default, two such pipelines are
created, "authorize", and "modelbind". These acts as
"placeholders" in the pipeline, where the end user
can easily insert their own steps.

Fixes #26