### PR TITLE
feat(vm): Specify moduleId at runtime

### DIFF
--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -37,6 +37,12 @@ export class RouterConfiguration{
 
   mapRoute(config) {
     this.instructions.push(router => {
+      var moduleStrategy = config.moduleStrategy;
+      if(moduleStrategy !== undefined &&
+        typeof moduleStrategy === 'function') {
+        config.moduleId = moduleStrategy(router);
+      }
+
       if (Array.isArray(config.route)) {
         var navModel = {}, i, ii, current;
 

--- a/src/router.js
+++ b/src/router.js
@@ -163,6 +163,7 @@ export class Router {
       config.viewPorts = {
         'default': {
           moduleId: config.moduleId,
+          moduleStrategy: config.moduleStrategy,
           view: config.view
         }
       };


### PR DESCRIPTION
feat(vm): Specify moduleId at runtime

This adds the possiblity do define a moduleStrategy which may be a
function. If present it will be executed and will rewrite the moduleId
of the given route. See https://github.com/aurelia/router/issues/3