### PR TITLE
feat(NavigationInstruction): merge params and queryParams into a single ...

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -1,11 +1,15 @@
+import core from 'core-js';
+
 export class NavigationInstruction {
   constructor(fragment, queryString, params, queryParams, config, parentInstruction) {
+    const allParams = Object.assign({}, queryParams, params);
+
     this.fragment = fragment;
     this.queryString = queryString;
     this.params = params || {};
     this.queryParams = queryParams;
     this.config = config;
-    this.lifecycleArgs = [params, queryParams, config, this];
+    this.lifecycleArgs = [allParams, config, this];
     this.viewPortInstructions = {};
 
     if (parentInstruction) {


### PR DESCRIPTION
...argument to activate and canActivate

BREAKING CHANGE: This is a breaking API change to the `activate` and `canActivate` view model callbacks. The first two arguments representing route params and query params have been merged into a single object. The signature is now `activate(params, config, navigationInstruction)`.

fixes #74