### PR TITLE
fix to support viewPorts in routes without moduleId or redirect + unit test

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -275,11 +275,11 @@ export class Router {
 
 function validateRouteConfig(config) {
   let isValid = typeof config === 'object'
-    && (config.moduleId || config.redirect)
+    && (config.moduleId || config.redirect || config.viewPorts)
     && config.route !== null && config.route !== undefined;
 
   if (!isValid) {
-    throw new Error('Invalid Route Config: You must have at least a route and a moduleId or redirect.');
+    throw new Error('Invalid Route Config: You must have at least a route and a moduleId, redirect, or viewPorts.');
   }
 }
 

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -57,6 +57,14 @@ describe('the router', () => {
       expect(() => router.addRoute({ route: 'test/:id', href: 'test', moduleId: 'test', nav: true })).not.toThrow();
       expect(() => router.addRoute({ route: 'test/:id', moduleId: 'test', nav: true })).toThrow();
     });
+
+    it('should add a route with multiple view ports', () => {
+      expect(() => router.addRoute({ route: 'multiple/viewports', viewPorts: {
+        'default': { moduleId: 'test1' },
+        'number2': { moduleId: 'test2' }
+      }})).not.toThrow();
+    });
+
   });
 
   describe('generate', () => {


### PR DESCRIPTION
This fixes what I believe is a bug; the following code causes the `validateRouteConfig` to throw an `Error` because it's currently expecting either `moduleId` or `redirect`.  

```
this.router.configure(config => {
      config.title = 'Aurelia';
      config.map('',
        {
          nav: true,
          title: 'Welcome',
          viewPorts: {
            'default': {
              moduleId: './welcome/welcome'
            },
            'dataTables': {
              moduleId: './plugins/dataTables/sample'
            }
          }
        });
    });
```

The included unit test validates this case.