### PR TITLE
fix(pipeline): fix bug preventing errors in pipeline steps from being handled

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -78,7 +78,7 @@ export class Pipeline {
     next.reject = error => {
       next.status = pipelineStatus.rejected;
       next.output = error;
-      return Promise.reject(createResult(ctx, next));
+      return Promise.resolve(createResult(ctx, next));
     };
 
     next.status = pipelineStatus.running;


### PR DESCRIPTION
fixes #85

AppRouter's [pipeline error handling](https://github.com/aurelia/router/blob/master/src/app-router.js#L72-L75) is designed to handle Promises that *resolve* with error results (not rejections). When `next.reject` returns a Promise *rejection* the error is intercepted by [catch handlers](https://github.com/aurelia/router/blob/master/src/navigation-plan.js#L83) in a couple places, which wrap the result in a second cancelled result and resolve. The `result` in AppRouter's continuation ends up being a `cancelled` result, whose `output` is an inner `rejected` result, which is handled as a nav cancellation instead of an error.

An alternative solution might be to keep the `Promise.reject()`, remove some or all of the `.catch()` handlers, and move `AppRouter`'s pipeline error handling out of the `.then()` into a `.catch()`. I'm not yet confident that it would be safe to remove the necessary `.catch()`s, and would need more time to study the code.