### PR TITLE
fix(router): using navigationStrategy throws a validation error

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -146,8 +146,8 @@ export class Router {
 
       if (typeof first.handler === 'function') {
         return evaluateNavigationStrategy(instruction, first.handler, first);
-      } else if(first.config && 'navigationStrategy' in first.config){
-        return evaluateNavigationStrategy(instruction, first.config.navigationStrategy, first.config);
+      } else if(first.handler && 'navigationStrategy' in first.handler){
+        return evaluateNavigationStrategy(instruction, first.handler.navigationStrategy, first.handler);
       }
 
       return Promise.resolve(instruction);
@@ -172,7 +172,7 @@ export class Router {
   addRoute(config, navModel={}) {
     validateRouteConfig(config);
 
-    if (!('viewPorts' in config)) {
+    if (!('viewPorts' in config) && !config.navigationStrategy) {
       config.viewPorts = {
         'default': {
           moduleId: config.moduleId,
@@ -278,11 +278,11 @@ export class Router {
 
 function validateRouteConfig(config) {
   let isValid = typeof config === 'object'
-    && (config.moduleId || config.redirect || config.viewPorts)
+    && (config.moduleId || config.redirect || config.navigationStrategy || config.viewPorts)
     && config.route !== null && config.route !== undefined;
 
   if (!isValid) {
-    throw new Error('Invalid Route Config: You must have at least a route and a moduleId, redirect, or viewPorts.');
+    throw new Error('Invalid Route Config: You must have at least a route and a moduleId, redirect, navigationStrategy or viewPorts.');
   }
 }
 


### PR DESCRIPTION
Trying to add a navigationStrategy to a route throws the following validation error:

`You must have at least a route and a moduleId, redirect, or viewPorts. at validateRouteConfig`

I've added the condition to the validation and made other changes to make the following route configuration work:

```
{
    route: ['', 'welcome'], nav: true, title: 'Welcome',
    navigationStrategy: function(instruction) {
        instruction.config.moduleId = 'welcome';
    }
}
```

The changes I've made fix some of the issues I encountered, but I'm not 100% sure it's the way that this is supposed to work, please review.