### PR TITLE
Replace route config property derivations with stricter validation

### DIFF
--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -25,7 +25,7 @@ export class RouterConfiguration{
       let routeConfigs = [];
 
       if (Array.isArray(config.route)) {
-        for (let i = 0, ii = config.route.length; i < ii; i++) {
+        for (let i = 0, ii = config.route.length; i < ii; ++i) {
           let current = Object.assign({}, config);
           current.route = config.route[i];
           routeConfigs.push(current);
@@ -35,7 +35,7 @@ export class RouterConfiguration{
       }
 
       let navModel;
-      for (let i = 0, ii = routeConfigs.length; i < ii; i++) {
+      for (let i = 0, ii = routeConfigs.length; i < ii; ++i) {
         let routeConfig = routeConfigs[i];
         routeConfig.settings = routeConfig.settings || {};
         if (!navModel) {
@@ -55,11 +55,8 @@ export class RouterConfiguration{
   }
 
   exportToRouter(router) {
-    var instructions = this.instructions,
-        pipelineSteps = this.pipelineSteps,
-        i, ii, filterContainer;
-
-    for (i = 0, ii = instructions.length; i < ii; ++i) {
+    let instructions = this.instructions;
+    for (let i = 0, ii = instructions.length; i < ii; ++i) {
       instructions[i](router);
     }
 
@@ -73,15 +70,15 @@ export class RouterConfiguration{
 
     router.options = this.options;
 
+    let pipelineSteps = this.pipelineSteps;
     if (pipelineSteps.length) {
-      // Pipeline steps should only be added at the app router
       if (!router.isRoot) {
         throw new Error('Pipeline steps can only be added to the root router');
       }
 
-      filterContainer = router.container.get(RouteFilterContainer);
-      for (i = 0, ii = pipelineSteps.length; i < ii; ++i) {
-        var {name, step} = pipelineSteps[i];
+      let filterContainer = router.container.get(RouteFilterContainer);
+      for (let i = 0, ii = pipelineSteps.length; i < ii; ++i) {
+        let {name, step} = pipelineSteps[i];
         filterContainer.addStep(name, step);
       }
     }

--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -11,28 +11,13 @@ export class RouterConfiguration{
     this.pipelineSteps.push({name, step});
   }
 
-  map(route, config) {
+  map(route) {
     if (Array.isArray(route)) {
-      for (var i = 0; i < route.length; i++) {
-        this.map(route[i]);
-      }
-
+      route.forEach(this.map.bind(this));
       return this;
     }
 
-    if (typeof route == 'string') {
-      if (!config) {
-        config = {};
-      } else if (typeof config == 'string') {
-        config = { moduleId: config };
-      }
-
-      config.route = route;
-    } else {
-      config = route;
-    }
-
-    return this.mapRoute(config);
+    return this.mapRoute(route);
   }
 
   mapRoute(config) {
@@ -52,7 +37,7 @@ export class RouterConfiguration{
       let navModel;
       for (let i = 0, ii = routeConfigs.length; i < ii; i++) {
         let routeConfig = routeConfigs[i];
-        this.ensureDefaultsForRouteConfig(routeConfig);
+        routeConfig.settings = routeConfig.settings || {};
         if (!navModel) {
           navModel = router.createNavModel(routeConfig);
         }
@@ -101,45 +86,4 @@ export class RouterConfiguration{
       }
     }
   }
-
-  ensureDefaultsForRouteConfig(config) {
-    config.name =  ensureConfigValue(config, 'name', this.deriveName);
-    config.route = ensureConfigValue(config, 'route', this.deriveRoute);
-    config.title = ensureConfigValue(config, 'title', this.deriveTitle);
-    config.moduleId = ensureConfigValue(config, 'moduleId', this.deriveModuleId);
-    config.settings = config.settings || {};
-  }
-
-  deriveName(config) {
-    return config.title || (config.route ? stripParametersFromRoute(config.route) : config.moduleId);
-  }
-
-  deriveRoute(config) {
-    return config.moduleId || config.name;
-  }
-
-  deriveTitle(config) {
-    var value = config.name;
-    return value ? value.substr(0, 1).toUpperCase() + value.substr(1) : null;
-  }
-
-  deriveModuleId(config) {
-    return stripParametersFromRoute(config.route);
-  }
-}
-
-function ensureConfigValue(config, property, getter) {
-  var value = config[property];
-
-  if (value || value === '') {
-    return value;
-  }
-
-  return getter(config);
-}
-
-function stripParametersFromRoute(route) {
-  var colonIndex = route.indexOf(':');
-  var length = colonIndex > 0 ? colonIndex - 1 : route.length;
-  return route.substr(0, length);
 }

--- a/src/router.js
+++ b/src/router.js
@@ -291,12 +291,16 @@ export class Router {
 }
 
 function validateRouteConfig(config) {
-  let isValid = typeof config === 'object'
-    && (config.moduleId || config.redirect || config.navigationStrategy || config.viewPorts)
-    && config.route !== null && config.route !== undefined;
+  if (typeof config !== 'object') {
+    throw new Error('Invalid Route Config');
+  }
 
-  if (!isValid) {
-    throw new Error('Invalid Route Config: You must have at least a route and a moduleId, redirect, navigationStrategy or viewPorts.');
+  if (typeof config.route !== 'string') {
+    throw new Error('Invalid Route Config: You must specify a route pattern.');
+  }
+
+  if (!(config.moduleId || config.redirect || config.navigationStrategy || config.viewPorts)) {
+    throw new Error('Invalid Route Config: You must specify a moduleId, redirect, navigationStrategy, or viewPorts.')
   }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: This is a breaking change to anyone relying on the `RouterConfiguration` to derive values for required route config properties. All config properties must now be specified explicitly.