### PR TITLE
fix(navigation-plan): handle redirects in child router configs

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -11,6 +11,7 @@ export class NavigationInstruction {
     this.config = config;
     this.lifecycleArgs = [allParams, config, this];
     this.viewPortInstructions = {};
+    this.parentInstruction = parentInstruction;
 
     if (parentInstruction) {
       this.params.$parent = parentInstruction.params;

--- a/src/navigation-plan.js
+++ b/src/navigation-plan.js
@@ -1,4 +1,5 @@
 import {Redirect} from './navigation-commands';
+import {resolveUrl} from './util';
 
 export const activationStrategy = {
   noChange: 'no-change',
@@ -10,6 +11,15 @@ export function buildNavigationPlan(navigationContext, forceLifecycleMinimum) {
   var prev = navigationContext.prevInstruction;
   var next = navigationContext.nextInstruction;
   var plan = {}, viewPortName;
+
+  if ('redirect' in next.config) {
+    let redirectLocation = resolveUrl(next.config.redirect, getInstructionBaseUrl(next));
+    if (next.queryString) {
+      redirectLocation += '?' + next.queryString;
+    }
+
+    return Promise.reject(new Redirect(redirectLocation));
+  }
 
   if (prev) {
     var newParams = hasDifferentParameterValues(prev, next);
@@ -71,17 +81,13 @@ export function buildNavigationPlan(navigationContext, forceLifecycleMinimum) {
 }
 
 export class BuildNavigationPlanStep {
-	run(navigationContext, next) {
-    if (navigationContext.nextInstruction.config.redirect) {
-      return next.cancel(new Redirect(navigationContext.nextInstruction.config.redirect));
-    }
-
+  run(navigationContext, next) {
     return buildNavigationPlan(navigationContext)
       .then(plan => {
         navigationContext.plan = plan;
         return next();
       }).catch(next.cancel);
-	}
+  }
 }
 
 function hasDifferentParameterValues(prev, next) {
@@ -100,4 +106,14 @@ function hasDifferentParameterValues(prev, next) {
   }
 
   return false;
+}
+
+function getInstructionBaseUrl(instruction) {
+    let instructionBaseUrlParts = [];
+    while(instruction = instruction.parentInstruction) {
+      instructionBaseUrlParts.unshift(instruction.getBaseUrl());
+    }
+
+    instructionBaseUrlParts.unshift('/');
+    return instructionBaseUrlParts.join('');
 }

--- a/src/route-loading.js
+++ b/src/route-loading.js
@@ -88,14 +88,15 @@ function loadRoute(routeLoader, navigationContext, viewPortPlan) {
 
       return childRouter.createNavigationInstruction(path, next)
         .then(childInstruction => {
-          viewPortPlan.childNavigationContext = childRouter.createNavigationContext(childInstruction);
+          let childNavigationContext = childRouter.createNavigationContext(childInstruction);
+          viewPortPlan.childNavigationContext = childNavigationContext;
 
-          return buildNavigationPlan(viewPortPlan.childNavigationContext)
+          return buildNavigationPlan(childNavigationContext)
             .then(childPlan => {
-              viewPortPlan.childNavigationContext.plan = childPlan;
-              viewPortInstruction.childNavigationContext = viewPortPlan.childNavigationContext;
+              childNavigationContext.plan = childPlan;
+              viewPortInstruction.childNavigationContext = childNavigationContext;
 
-              return loadNewRoute(routeLoader, viewPortPlan.childNavigationContext);
+              return loadNewRoute(routeLoader, childNavigationContext);
             });
         });
     }

--- a/src/util.js
+++ b/src/util.js
@@ -17,3 +17,42 @@ export function processPotential(obj, resolve, reject){
     }
   }
 }
+
+export function normalizeAbsolutePath(path, hasPushState) {
+    if (!hasPushState && path[0] !== '#') {
+      path = '#' + path;
+    }
+
+    return path;
+}
+
+export function createRootedPath(fragment, baseUrl, hasPushState) {
+  if (isAbsoluteUrl.test(fragment)) {
+    return fragment;
+  }
+
+  let path = '';
+
+  if (baseUrl.length && baseUrl[0] !== '/') {
+    path += '/';
+  }
+
+  path += baseUrl;
+
+  if (path[path.length - 1] != '/' && fragment[0] != '/') {
+    path += '/';
+  }
+
+  return normalizeAbsolutePath(path + fragment, hasPushState);
+}
+
+export function resolveUrl(fragment, baseUrl, hasPushState) {
+  if (isRootedPath.test(fragment)) {
+    return normalizeAbsolutePath(fragment, hasPushState);
+  } else {
+    return createRootedPath(fragment, baseUrl, hasPushState);
+  }
+}
+
+const isRootedPath = /^#?\//;
+const isAbsoluteUrl = /^([a-z][a-z0-9+\-.]*:)?\/\//i;


### PR DESCRIPTION
This change fixes several issues with configs specifying redirects.
 * The pipeline now properly handles route configs specifying redirects in child routers. Previously this was only handled for the top-level routes in `BuildNavigationPlanStep`.
* A redirect location of '' is now accepted.
* Redirect locations are now resolved relative to the navigation instruction rather than assumed to be relative.
* Query strings are now preserved across redirects.

fixes #103