### PR TITLE
fix(router): incorrectly comparing routes parameter values in navigation plan

### DIFF
--- a/src/navigation-plan.js
+++ b/src/navigation-plan.js
@@ -99,5 +99,11 @@ function hasDifferentParameterValues(prev, next) {
     }
   }
 
+  for (var key in prevParams) {
+    if (prevParams[key] !== nextParams[key]) {
+      return true;
+    }
+  }
+
   return false;
 }

--- a/src/navigation-plan.js
+++ b/src/navigation-plan.js
@@ -90,16 +90,20 @@ function hasDifferentParameterValues(prev, next) {
       nextWildCardName = next.config.hasChildRouter ? next.getWildCardName() : null;
 
   for (var key in nextParams) {
-    if (key == nextWildCardName) {
+    if (key === nextWildCardName) {
       continue;
     }
 
-    if (prevParams[key] != nextParams[key]) {
+    if (prevParams[key] !== nextParams[key]) {
       return true;
     }
   }
 
   for (var key in prevParams) {
+    if (key === nextWildCardName) {
+      continue;
+    }
+
     if (prevParams[key] !== nextParams[key]) {
       return true;
     }


### PR DESCRIPTION
When checking if the routes parameters changed when navigating between views, the logic does not take into account when the next route parameters does not contain parameters from the previous one.

It works fine in this example: 
Current view params: `{ param1: 'someValue' }`
Next view params: `{ param1: 'someValue', param2: 'anotherValue' }`

It does not work in the opposite direction:
Current view params: `{ param1: 'someValue', param2: 'anotherValue' }`
Next view params: `{ param1: 'someValue' }`

because it iterates through only the next route parameters, comparing `param1` without noticing that `param2` is now missing compared to the previous view.

There might be a smarter way to compare the two objects, so it might be better refactored, but wasn't sure of how the wildcards should be handled.