### PR TITLE
fix(router): a route with path '/' breaks handleUnknownRoutes

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -175,14 +175,20 @@ export class Router {
     }
 
     this.routes.push(config);
-    let state = this.recognizer.add({path:config.route, handler: config});
 
-    if (config.route) {
+    let path = config.route;
+    if (path.charAt(0) === '/') {
+      path = path.substr(1);
+    }
+
+    let state = this.recognizer.add({path: path, handler: config});
+
+    if (path) {
       let withChild, settings = config.settings;
       delete config.settings;
       withChild = JSON.parse(JSON.stringify(config));
       config.settings = settings;
-      withChild.route += '/*childRoute';
+      withChild.route = `${path}/*childRoute`;
       withChild.hasChildRouter = true;
       this.childRecognizer.add({
         path: withChild.route,


### PR DESCRIPTION
Strip leading slash from route paths before registering child handlers to avoid adding bad route paths to child recognizers.

fixes #116