### PR TITLE
Refactor dequeueInstruction to improve nav events and error handling

### DIFF
--- a/config.js
+++ b/config.js
@@ -19,6 +19,7 @@ System.config({
     "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.8.1",
     "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.5.0",
     "aurelia-history": "github:aurelia/history@0.5.0",
+    "aurelia-logging": "github:aurelia/logging@0.5.0",
     "aurelia-path": "github:aurelia/path@0.7.0",
     "aurelia-route-recognizer": "github:aurelia/route-recognizer@0.5.0",
     "babel": "npm:babel-core@5.2.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.8.1",
       "aurelia-event-aggregator": "github:aurelia/event-aggregator@^0.5.0",
       "aurelia-history": "github:aurelia/history@^0.5.0",
+      "aurelia-logging": "github:aurelia/logging@^0.5.0",
       "aurelia-path": "github:aurelia/path@^0.7.0",
       "aurelia-route-recognizer": "github:aurelia/route-recognizer@^0.5.0",
       "core-js": "npm:core-js@^0.9.5"

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -58,8 +58,12 @@ export class AppRouter extends Router {
 
       if (!instructionCount) {
         this.events.publish('router:navigation:processing', { instruction });
+      } else if (instructionCount === this.maxInstructionCount - 1) {
+        logger.error(`${instructionCount + 1} navigation instructions have been attempted without success. Restoring last known good location.`);
+        restorePreviousLocation(this);
+        return this.dequeueInstruction(instructionCount + 1);
       } else if (instructionCount > this.maxInstructionCount) {
-        throw new Error(`Maximum navigation attempts exceeded. ${this.maxInstructionCount} navigation instructions have been attempted without success. Giving up.`);
+        throw new Error(`Maximum navigation attempts exceeded. Giving up.`);
       }
 
       let context = this.createNavigationContext(instruction);

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -204,7 +204,7 @@ function resolveInstruction(instruction, result, isInnerInstruction, router) {
 function restorePreviousLocation(router) {
   let previousLocation = router.history.previousLocation;
   if (previousLocation) {
-    router.navigate(router.history.previousLocation, false);
+    router.navigate(router.history.previousLocation, { trigger: false, replace: true });
   } else {
     console.error('Router navigation failed, and no previous location could be restored.');
   }

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -1,4 +1,5 @@
 import core from 'core-js';
+import * as LogManager from 'aurelia-logging';
 import {Container} from 'aurelia-dependency-injection';
 import {History} from 'aurelia-history';
 import {Router} from './router';
@@ -6,6 +7,8 @@ import {PipelineProvider} from './pipeline-provider';
 import {isNavigationCommand} from './navigation-commands';
 import {EventAggregator} from 'aurelia-event-aggregator';
 import {RouterConfiguration} from './router-configuration';
+
+const logger = LogManager.getLogger('app-router');
 
 export class AppRouter extends Router {
   static inject(){ return [Container, History, PipelineProvider, EventAggregator]; }
@@ -25,7 +28,7 @@ export class AppRouter extends Router {
     return this.createNavigationInstruction(url)
       .then(instruction => this.queueInstruction(instruction))
       .catch(error => {
-        console.error(error);
+        logger.error(error);
         restorePreviousLocation(this);
       });
   }
@@ -206,6 +209,6 @@ function restorePreviousLocation(router) {
   if (previousLocation) {
     router.navigate(router.history.previousLocation, { trigger: false, replace: true });
   } else {
-    console.error('Router navigation failed, and no previous location could be restored.');
+    logger.error('Router navigation failed, and no previous location could be restored.');
   }
 }

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -189,7 +189,8 @@ function resolveInstruction(instruction, result, isInnerInstruction, router) {
     } else if (!result.completed) {
       eventName = 'canceled';
     } else {
-      router.history.previousFragment = instruction.fragment;
+      let queryString = instruction.queryString ? ('?' + instruction.queryString) : '';
+      router.history.previousLocation = instruction.fragment + queryString;
       eventName = 'success';
     }
 


### PR DESCRIPTION
* All navigations now raise 3 events: `processing`, (`success` | `error` | `canceled`), and `complete`.
* All navigation events include the same event args: `{ instruction, result }`, except for `processing`, which omits the result property.
* A maximum of 10 instruction executions are attempted before giving up with a navigation error.
* Unexpected return values from the pipeline are now handled as error results instead of crashing.