### PR TITLE
WIP: Force continue if 'router.viewPorts' is empty.

### DIFF
--- a/src/navigation-context.js
+++ b/src/navigation-context.js
@@ -54,7 +54,10 @@ export class NavigationContext {
       var viewPort = router.viewPorts[viewPortName];
 
       if(!viewPort){
-        throw new Error(`There was no router-view found in the view for ${viewPortInstruction.moduleId}.`);
+        if (!Object.keys(router.viewPorts).length) {
+          return;
+        }
+        throw new Error(`There was no router-view found in the view for the module ${viewPortInstruction.moduleId}.`);
       }
 
       if (viewPortInstruction.strategy === activationStrategy.replace) {


### PR DESCRIPTION
#134 

As far i understood, the ``child router`` is commited for each ``viewPort`` defined in the parent router. 

The error is generated when don't found `route-view`  defined in one of the view port (in this case ``menu-options``)

I'll expect only expected the ``child route`` only will commit on the view port defined.

Now i make a bypass of the exception, when the viewPorts are empty.

@bryanrsmith, @EisenbergEffect could you help me, to understand better about (relation between router, view (viewPorts), navigation) to found source of the problem to improve the fix?   

thanks