### PR TITLE
Lists all properties on the class directly.

### DIFF
--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -1,11 +1,11 @@
 import {RouteFilterContainer} from './route-filters';
 
 export class RouterConfiguration{
-  constructor() {
-    this.instructions = [];
-    this.options = {};
-    this.pipelineSteps = [];
-  }
+  instructions = [];
+  options = {};
+  pipelineSteps = [];
+  title;
+  unknownRouteConfig;
 
   addPipelineStep(name, step) {
     this.pipelineSteps.push({name, step});


### PR DESCRIPTION
Fixes #146.

I'm not sure if empty properties will make it to the d.ts or not (they are compiled out when transpiling to ES5 I believe).  I could default them to null, though I'm worried that some area of the code may treat null and undefined differently.  Alternatively, #146 could be fixed by adding a setter for `title` (`unknownRouteConfig` already has one).  I prefer this method, as it makes it clear at the top of the class what all the properties of it are, but perhaps people shouldn't be reading from these, only setting them in which case the public interface is really set-only, so a function for each would be better.