### PR TITLE
fix(router): Use correct import for core-js

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import * as LogManager from 'aurelia-logging';
 import {Container} from 'aurelia-dependency-injection';
 import {History} from 'aurelia-history';

--- a/src/navigation-commands.js
+++ b/src/navigation-commands.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 
 /**
  * Determines if the provided object is a navigation command.

--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 
 export class NavigationInstruction {
   fragment: string;

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 
 function createResult(ctx, next) {
   return {

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {RouteRecognizer} from 'aurelia-route-recognizer';
 import {join} from 'aurelia-path';
 import {Container} from 'aurelia-dependency-injection';


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177