### PR TITLE
Fix typo 'resut'

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -184,7 +184,7 @@ function targetIsThisWindow(target) {
 
 function processResult(instruction, result, instructionCount, router) {
   if (!(result && 'completed' in result && 'output' in result)) {
-    resut = result || {};
+    result = result || {};
     result.output = new Error(`Expected router pipeline to return a navigation result, but got [${JSON.stringify(result)}] instead.`);
   }
 


### PR DESCRIPTION
Typo causes an exception which is swallowed up and not displayed in console.