### PR TITLE
feat(router): add ensureConfigured method

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -29,6 +29,9 @@ export class Router {
   constructor(container, history) {
     this.container = container;
     this.history = history;
+    this._configuredPromise = new Promise((resolve => {
+      this._resolveConfiguredPromise = resolve;
+    }));
     this.reset();
   }
 
@@ -57,9 +60,11 @@ export class Router {
     }
   }
 
-  configure(callbackOrConfig:RouterConfiguration|((config:RouterConfiguration) => RouterConfiguration)):Router {
-    this.isConfigured = true;
+  ensureConfigured() {
+    return this._configuredPromise;
+  }
 
+  configure(callbackOrConfig:RouterConfiguration|((config:RouterConfiguration) => RouterConfiguration)):Router {
     if (typeof callbackOrConfig == 'function') {
       var config = new RouterConfiguration();
       callbackOrConfig(config);
@@ -67,6 +72,9 @@ export class Router {
     } else {
       callbackOrConfig.exportToRouter(this);
     }
+
+    this.isConfigured = true;
+    this._resolveConfiguredPromise();
 
     return this;
   }

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -237,4 +237,36 @@ describe('the router', () => {
         .then(done);
     });
   });
+
+  describe('configure', () => {
+    it('notifies when configured', (done) => {
+      expect(router.isConfigured).toBe(false);
+
+      router.ensureConfigured().then(() => {
+        expect(router.isConfigured).toBe(true);
+        done();
+      });
+
+      router.configure(config => {
+        config.map({ route: '', moduleId: './test' });
+      });
+
+      expect(router.isConfigured).toBe(true);
+    });
+
+    it('notifies when already configured', (done) => {
+      expect(router.isConfigured).toBe(false);
+
+      router.configure(config => {
+        config.map({ route: '', moduleId: './test' });
+      });
+
+      expect(router.isConfigured).toBe(true);
+
+      router.ensureConfigured().then(() => {
+        expect(router.isConfigured).toBe(true);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
ensureConfigured returns a Promise that resolves when the router is configured. Useful for easily building functionality that must wait for async router configurations.

Supports fix for aurelia/framework#158