### PR TITLE
refactor(pipeline): rename cancelled pipelineStatus to canceled for c…

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -11,7 +11,7 @@ function createResult(ctx, next) {
 
 export const pipelineStatus = {
   completed: 'completed',
-  cancelled: 'cancelled',
+  canceled: 'canceled',
   rejected: 'rejected',
   running: 'running'
 };
@@ -70,7 +70,7 @@ export class Pipeline {
     };
 
     next.cancel = reason => {
-      next.status = pipelineStatus.cancelled;
+      next.status = pipelineStatus.canceled;
       next.output = reason;
       return Promise.resolve(createResult(ctx, next));
     };

--- a/test/app-router.spec.js
+++ b/test/app-router.spec.js
@@ -145,7 +145,7 @@ describe('app-router', () => {
       router.dequeueInstruction()
         .then(result => {
           expect(result.completed).toBe(false);
-          expect(result.status).toBe('cancelled');
+          expect(result.status).toBe('canceled');
           expect(result.output).toBe(output);
           expect(result.context).toBeTruthy();
         })


### PR DESCRIPTION
…onsistency

BREAKING CHANGE: This is a minor breaking change to any code inspecting instruction pipeline status. To update, change uses of the property or string value `cancelled` to `canceled`.