### PR TITLE
fix(router): properly handle async router configurations

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -6,7 +6,6 @@ import {Router} from './router';
 import {PipelineProvider} from './pipeline-provider';
 import {isNavigationCommand} from './navigation-commands';
 import {EventAggregator} from 'aurelia-event-aggregator';
-import {RouterConfiguration} from './router-configuration';
 
 const logger = LogManager.getLogger('app-router');
 
@@ -85,21 +84,19 @@ export class AppRouter extends Router {
 
     if (!this.isActive) {
       let viewModel = this._findViewModel(viewPort);
-
       if ('configureRouter' in viewModel) {
-        let config = new RouterConfiguration();
-        let result = Promise.resolve(viewModel.configureRouter(config, this));
-
-        return result.then(() => {
-          this.configure(config);
-          this.activate();
-        });
+        if (!this.isConfigured) {
+          return this.configure(config => viewModel.configureRouter(config, this))
+            .then(() => { this.activate(); });
+        }
+      } else {
+        this.activate();
       }
-
-      this.activate();
     } else {
       this.dequeueInstruction();
     }
+
+    return Promise.resolve();
   }
 
   _findViewModel(viewPort: Object) {

--- a/src/route-loading.js
+++ b/src/route-loading.js
@@ -1,5 +1,4 @@
 import {activationStrategy, buildNavigationPlan} from './navigation-plan';
-import {RouterConfiguration} from './router-configuration';
 
 export class RouteLoader {
   loadRoute(router: any, config: any, navigationContext: any) {
@@ -105,19 +104,16 @@ function loadComponent(routeLoader: RouteLoader, navigationContext: NavigationCo
   let lifecycleArgs = navigationContext.nextInstruction.lifecycleArgs;
 
   return routeLoader.loadRoute(router, config, navigationContext).then((component) => {
+    let {bindingContext, childContainer} = component;
     component.router = router;
     component.config = config;
 
-    if ('configureRouter' in component.bindingContext) {
-      component.childRouter = component.childContainer.getChildRouter();
+    if ('configureRouter' in bindingContext) {
+      let childRouter = childContainer.getChildRouter();
+      component.childRouter = childRouter;
 
-      let routerConfig = new RouterConfiguration();
-      let result = Promise.resolve(component.bindingContext.configureRouter(routerConfig, component.childRouter, ...lifecycleArgs));
-
-      return result.then(() => {
-        component.childRouter.configure(routerConfig);
-        return component;
-      });
+      return childRouter.configure(c => bindingContext.configureRouter(c, childRouter, ...lifecycleArgs))
+        .then(() => component);
     }
 
     return component;

--- a/src/router.js
+++ b/src/router.js
@@ -91,23 +91,22 @@ export class Router {
   * Configures the router.
   *
   * @param callbackOrConfig The [[RouterConfiguration]] or a callback that takes a [[RouterConfiguration]].
-  * @chainable
   */
-  configure(callbackOrConfig: RouterConfiguration|((config: RouterConfiguration) => RouterConfiguration)): Router {
+  configure(callbackOrConfig: RouterConfiguration|((config: RouterConfiguration) => RouterConfiguration)): Promise {
     this.isConfigured = true;
 
+    let result = callbackOrConfig;
+    let config;
     if (typeof callbackOrConfig === 'function') {
-      let config = new RouterConfiguration();
-      callbackOrConfig(config);
-      config.exportToRouter(this);
-    } else {
-      callbackOrConfig.exportToRouter(this);
+      config = new RouterConfiguration();
+      result = callbackOrConfig(config);
     }
 
-    this.isConfigured = true;
-    this._resolveConfiguredPromise();
-
-    return this;
+    return Promise.resolve(result).then((c) => {
+      (c || config).exportToRouter(this);
+      this.isConfigured = true;
+      this._resolveConfiguredPromise();
+    });
   }
 
   /**

--- a/test/app-router.spec.js
+++ b/test/app-router.spec.js
@@ -85,6 +85,27 @@ describe('app-router', () => {
       });
   });
 
+  it('configures only once with multiple viewPorts', (done) => {
+    let routeConfig = { route: '', moduleId: './test' };
+    let viewModel = {
+      configureRouter(config) {
+        config.map([routeConfig]);
+      }
+    };
+
+    spyOn(viewModel, 'configureRouter').and.callThrough();
+
+    container.viewModel = viewModel;
+
+    Promise.all([router.registerViewPort(viewPort), router.registerViewPort(viewPort, 'second')])
+      .then(result => {
+        expect(viewModel.configureRouter.calls.count()).toBe(1);
+        expect(router.isConfigured).toBe(true);
+        expect(router.routes.length).toBe(1);
+        done();
+      });
+  });
+
   describe('dequeueInstruction', () => {
     let processingResult;
     let completedResult;


### PR DESCRIPTION
This change moves handling of async router config callbacks into Router.configure to resolve a race condition when using multiple viewPorts. Async configuration was previously handled externally in app-router and route-loading, but that code failed to block subsequent calls from configuring multiple times. Router.configure() now handles async callbacks, setting isConfigured immeditely to allow callers to check state.

BREAKING CHANGES:
  * Router.configure() now always returns a Promise, and is no longer chainable.
  * Router.configure() now applies the configuration in a Promise continuation, so it is not safe to assume that the router will be configured synchronously when the configuration callback is synchronous.

fixes #213