### PR TITLE
Returning null to signal that we didn't forget to return

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -212,6 +212,7 @@ export class NavigationInstruction {
 
     return Promise.all(loads).then(() => {
       delaySwaps.forEach(x => x.viewPort.swap(x.viewPortInstruction));
+      return null;
     }).then(() => prune(this));
   }
 


### PR DESCRIPTION
This avoids lengthy warning when using bluebird library for promises.