### PR TITLE
fix(router): log helpful error on missing viewport

### DIFF
--- a/src/navigation-plan.js
+++ b/src/navigation-plan.js
@@ -41,6 +41,9 @@ export function _buildNavigationPlan(instruction: NavigationInstruction, forceLi
     for (let viewPortName in prev.viewPortInstructions) {
       let prevViewPortInstruction = prev.viewPortInstructions[viewPortName];
       let nextViewPortConfig = config.viewPorts[viewPortName];
+
+      if (!nextViewPortConfig) throw new Error(`Invalid Route Config: Configuration for viewPort "${viewPortName}" was not found for route: "${instruction.config.route}."`);
+
       let viewPortPlan = plan[viewPortName] = {
         name: viewPortName,
         config: nextViewPortConfig,


### PR DESCRIPTION
When a route does not configure all available viewports, the navigation plan will crash. Now, the navigation plan will log a helpful error with the missing viewport and the affected route.

Fixes #241.