### PR TITLE
fix(router): add NavModel to RouteConfig interface

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -63,5 +63,10 @@ interface RouteConfig {
   */
   settings?: any;
 
+  /**
+  * The navigation model for storing and interacting with the route's navigation settings.
+  */
+  navModel?: NavModel;
+
   [x: string]: any;
 }


### PR DESCRIPTION
The property "navModel" exists on the RouteConfig object, but it was missing from the interface, breaking Typescript. It is now added.

Fixes #285.