### PR TITLE
feat(router): generate absolute URI from router

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,7 +22,7 @@ System.config({
     "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.0.0-beta.1.1.0",
     "babel": "npm:babel-core@5.8.35",
     "babel-runtime": "npm:babel-runtime@5.8.35",
-    "core-js": "npm:core-js@2.0.3",
+    "core-js": "npm:core-js@2.1.0",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },
@@ -42,23 +42,27 @@ System.config({
       "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
-      "core-js": "npm:core-js@2.0.3"
+      "core-js": "npm:core-js@2.1.0"
     },
     "npm:aurelia-event-aggregator@1.0.0-beta.1.1.0": {
       "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.1"
     },
     "npm:aurelia-metadata@1.0.0-beta.1.1.3": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
-      "core-js": "npm:core-js@2.0.3"
+      "core-js": "npm:core-js@2.1.0"
+    },
+    "npm:aurelia-pal-browser@1.0.0-beta.1.1.3": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "core-js": "npm:core-js@2.1.0"
     },
     "npm:aurelia-route-recognizer@1.0.0-beta.1.1.0": {
       "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.1.0",
-      "core-js": "npm:core-js@2.0.3"
+      "core-js": "npm:core-js@2.1.0"
     },
     "npm:babel-runtime@5.8.35": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:core-js@2.0.3": {
+    "npm:core-js@2.1.0": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
       "aurelia-route-recognizer": "^1.0.0-beta.1.1.0"
     },
     "devDependencies": {
+      "aurelia-pal-browser": "^1.0.0-beta.1.1.3",
       "babel": "babel-core@^5.8.24",
       "babel-runtime": "^5.8.24",
       "core-js": "^2.0.3"

--- a/src/router.js
+++ b/src/router.js
@@ -187,7 +187,7 @@ export class Router {
   * @param params The route params to be used to populate the route pattern.
   * @returns {string} A string containing the generated URL fragment.
   */
-  generate(name: string, params?: any): string {
+  generate(name: string, params?: any, options?: any = {}): string {
     let hasRoute = this._recognizer.hasRoute(name);
     if ((!this.isConfigured || !hasRoute) && this.parent) {
       return this.parent.generate(name, params);
@@ -198,7 +198,8 @@ export class Router {
     }
 
     let path = this._recognizer.generate(name, params);
-    return _createRootedPath(path, this.baseUrl, this.history._hasPushState);
+    let rootedPath = _createRootedPath(path, this.baseUrl, this.history._hasPushState, options.absolute);
+    return options.absolute ? `${this.history.getAbsoluteRoot()}${rootedPath}` : rootedPath;
   }
 
   /**

--- a/src/util.js
+++ b/src/util.js
@@ -1,12 +1,16 @@
-export function _normalizeAbsolutePath(path, hasPushState) {
+export function _normalizeAbsolutePath(path, hasPushState, absolute = false) {
   if (!hasPushState && path[0] !== '#') {
     path = '#' + path;
+  }
+
+  if (hasPushState && absolute) {
+    path = path.substring(1, path.length);
   }
 
   return path;
 }
 
-export function _createRootedPath(fragment, baseUrl, hasPushState) {
+export function _createRootedPath(fragment, baseUrl, hasPushState, absolute) {
   if (isAbsoluteUrl.test(fragment)) {
     return fragment;
   }
@@ -27,7 +31,7 @@ export function _createRootedPath(fragment, baseUrl, hasPushState) {
     path = path.substring(0, path.length - 1);
   }
 
-  return _normalizeAbsolutePath(path + fragment, hasPushState);
+  return _normalizeAbsolutePath(path + fragment, hasPushState, absolute);
 }
 
 export function _resolveUrl(fragment, baseUrl, hasPushState) {

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -3,11 +3,16 @@ import {Container} from 'aurelia-dependency-injection';
 import {AppRouter} from '../src/app-router';
 import {PipelineProvider} from '../src/pipeline-provider';
 
+let absoluteRoot = 'http://aurelia.io/docs/';
+
 class MockHistory extends History {
   activate() {}
   deactivate() {}
   navigate() {}
   navigateBack() {}
+  getAbsoluteRoot() {
+    return absoluteRoot;
+  }
 }
 
 describe('the router', () => {
@@ -108,6 +113,22 @@ describe('the router', () => {
         expect(child.generate('parent', { id: 1 })).toBe('#/parent/1');
         done();
       });
+    });
+
+    it('should return a fully-qualified URL when options.absolute is true', (done) => {
+      const child = router.createChild(new Container());
+      let options = { absolute: true };
+
+      child.configure(config => config.map({ name: 'test', route: 'test/:id', moduleId: './test' }))
+        .then(() => {
+          expect(child.generate('test', { id: 1 }, options)).toBe(`${absoluteRoot}#/test/1`);
+
+          router.history._hasPushState = true;
+
+          expect(child.generate('test', { id: 1 }, options)).toBe(`${absoluteRoot}test/1`);
+
+          done();
+        });
     });
   });
 


### PR DESCRIPTION
Adds an extra boolean argument to `router.generate` to specify whether or not to generate an absolute URI.

Fixes #88.