### PR TITLE
refactor(router): rename pipeline slots

### DIFF
--- a/src/pipeline-provider.js
+++ b/src/pipeline-provider.js
@@ -23,15 +23,15 @@ export class PipelineProvider {
       BuildNavigationPlanStep,
       CanDeactivatePreviousStep, //optional
       LoadRouteStep,
-      createRouteFilterStep('authorize'),
-      createRouteFilterStep('modelbind'),
+      createRouteFilterStep(pipelineSlot.authorize),
       CanActivateNextStep, //optional
+      createRouteFilterStep(pipelineSlot.preActivate, { aliases: ['modelbind']}),
       //NOTE: app state changes start below - point of no return
       DeactivatePreviousStep, //optional
       ActivateNextStep, //optional
-      createRouteFilterStep('precommit'),
+      createRouteFilterStep(pipelineSlot.preRender, { aliases: ['precommit']}),
       CommitChangesStep,
-      createRouteFilterStep('postcomplete')
+      createRouteFilterStep(pipelineSlot.postRender, { aliases: ['postcomplete']})
     ];
   }
 
@@ -44,3 +44,10 @@ export class PipelineProvider {
     return pipeline;
   }
 }
+
+const pipelineSlot = {
+  authorize: 'authorize',
+  preActivate: 'preActivate',
+  preRender: 'preRender',
+  postRender: 'postRender'
+};

--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -26,6 +26,46 @@ export class RouterConfiguration {
   }
 
   /**
+  * Adds a step to be run during the [[Router]]'s authorize pipeline slot.
+  *
+  * @param step The pipeline step.
+  * @chainable
+  */
+  addAuthorizeStep(step: Function|PipelineStep): RouterConfiguration {
+    return this.addPipelineStep('authorize', step);
+  }
+
+  /**
+  * Adds a step to be run during the [[Router]]'s preActivate pipeline slot.
+  *
+  * @param step The pipeline step.
+  * @chainable
+  */
+  addPreActivateStep(step: Function|PipelineStep): RouterConfiguration {
+    return this.addPipelineStep('preActivate', step);
+  }
+
+  /**
+  * Adds a step to be run during the [[Router]]'s preRender pipeline slot.
+  *
+  * @param step The pipeline step.
+  * @chainable
+  */
+  addPreRenderStep(step: Function|PipelineStep): RouterConfiguration {
+    return this.addPipelineStep('preRender', step);
+  }
+
+  /**
+  * Adds a step to be run during the [[Router]]'s postRender pipeline slot.
+  *
+  * @param step The pipeline step.
+  * @chainable
+  */
+  addPostRenderStep(step: Function|PipelineStep): RouterConfiguration {
+    return this.addPipelineStep('postRender', step);
+  }
+
+  /**
   * Maps one or more routes to be registered with the router.
   *
   * @param route The [[RouteConfig]] to map, or an array of [[RouteConfig]] to map.

--- a/test/route-filters.spec.js
+++ b/test/route-filters.spec.js
@@ -1,0 +1,97 @@
+import {Container} from 'aurelia-dependency-injection';
+import {RouteFilterContainer, createRouteFilterStep} from '../src/route-filters';
+
+describe('createRouteFilterStep', () => {
+  it('should return a function', () => {
+    let name = 'step';
+    let options = { aliases: ['step2']};
+
+    expect(typeof createRouteFilterStep(name)).toBe('function');
+    expect(typeof createRouteFilterStep(name, options)).toBe('function');
+  });
+});
+
+describe('createRouteFilterStep => create', () => {
+  let routeFilterContainer;
+  beforeEach(() => {
+    routeFilterContainer = new RouteFilterContainer(new Container());
+  });
+
+  it('should return a valid object', () => {
+    let name = 'step';
+    let options = { aliases: ['step2']};
+
+    expect(createRouteFilterStep(name)(routeFilterContainer)).not.toBeUndefined();
+    expect(createRouteFilterStep(name, options)(routeFilterContainer)).not.toBeUndefined();
+  });
+
+  it('should call the register method on the routeFilterContainer', () => {
+    let name = 'step';
+    let aliases = ['alias1', 'alias2'];
+    let options = { aliases: aliases };
+    spyOn(routeFilterContainer, 'register');
+
+    createRouteFilterStep(name)(routeFilterContainer);
+    expect(routeFilterContainer.register).toHaveBeenCalled();
+
+    createRouteFilterStep(name, options)(routeFilterContainer);
+    expect(routeFilterContainer.register).toHaveBeenCalled();
+  });
+});
+
+describe('RouteFilterContainer', () => {
+  let routeFilterContainer;
+  beforeEach(() => {
+    routeFilterContainer = new RouteFilterContainer(new Container());
+  });
+
+  describe('register', () => {
+    it('should populate the lookup hash', () => {
+      let key = 'step';
+      let aliases = ['alias1', 'alias2'];
+
+      routeFilterContainer.register(key, aliases);
+      aliases.forEach((alias) => {
+        expect(routeFilterContainer.lookup[alias]).toBe(key);
+      });
+    });
+  });
+
+  describe('addStep', () => {
+    it('should handle addition by names and aliases', () => {
+      let keys = ['preRender', 'postRender'];
+      let lookup = {
+        preRender: keys[0],
+        precommit: keys[0],
+        postRender: keys[1],
+        postcomplete: keys[1]
+      };
+
+      routeFilterContainer.lookup = lookup;
+
+      routeFilterContainer.addStep('preRender', Function.prototype);
+      routeFilterContainer.addStep('precommit', Function.prototype);
+      expect(routeFilterContainer.filters[keys[0]].length).toEqual(2);
+
+      routeFilterContainer.addStep('postRender', Function.prototype);
+      routeFilterContainer.addStep('postcomplete', Function.prototype);
+      routeFilterContainer.addStep('postRender', Function.prototype);
+
+      expect(routeFilterContainer.filters[keys[1]].length).toEqual(3);
+    });
+  });
+
+  describe('getFilterSteps', () => {
+    it('should return an array of steps for a given key', () => {
+      let filters = {};
+      let keys = ['step1', 'step2'];
+      let step = { getSteps: 'foo' };
+      keys.forEach((key) => {
+        filters[key] = [step, step];
+      });
+
+      routeFilterContainer.filters = filters;
+      expect(routeFilterContainer.getFilterSteps(keys[0])).toEqual([step, step]);
+    });
+  });
+});


### PR DESCRIPTION
Pipeline slots have been renamed: 'modelbind' is 'preActivate', 'precommit' is 'preRender', and 'postcomplete' is 'postRender'. Sugar methods have been added to support the new names. RouteFilterContainers now support aliases in order to preserve backwards compatibility. Tests have been added for 'route-filters.js'.

Fixes #295.