### PR TITLE
feat(router): add option to compare query params

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -6,7 +6,8 @@ interface NavigationInstructionInit {
   config: RouteConfig,
   parentInstruction: NavigationInstruction,
   previousInstruction: NavigationInstruction,
-  router: Router
+  router: Router,
+  options: Object
 }
 
 export class CommitChangesStep {
@@ -63,6 +64,8 @@ export class NavigationInstruction {
   viewPortInstructions: any;
 
   plan: Object = null;
+
+  options: Object = {};
 
   constructor(init: NavigationInstructionInit) {
     Object.assign(this, init);

--- a/src/navigation-plan.js
+++ b/src/navigation-plan.js
@@ -121,6 +121,24 @@ function hasDifferentParameterValues(prev: NavigationInstruction, next: Navigati
     }
   }
 
+  if (!next.options.compareQueryParams) {
+    return false;
+  }
+
+  let prevQueryParams = prev.queryParams;
+  let nextQueryParams = next.queryParams;
+  for (let key in nextQueryParams) {
+    if (prevQueryParams[key] !== nextQueryParams[key]) {
+      return true;
+    }
+  }
+
+  for (let key in prevQueryParams) {
+    if (prevQueryParams[key] !== nextQueryParams[key]) {
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/src/router.js
+++ b/src/router.js
@@ -51,6 +51,8 @@ export class Router {
   */
   parent: Router = null;
 
+  options: Object = {};
+
   /**
   * @param container The [[Container]] to use when child routers.
   * @param history The [[History]] implementation to delegate navigation requests to.
@@ -369,7 +371,10 @@ export class Router {
       config: null,
       parentInstruction,
       previousInstruction: this.currentInstruction,
-      router: this
+      router: this,
+      options: {
+        compareQueryParams: this.options.compareQueryParams
+      }
     };
 
     if (results && results.length) {

--- a/test/navigation-plan.spec.js
+++ b/test/navigation-plan.spec.js
@@ -141,5 +141,19 @@ describe('NavigationPlanStep', () => {
         done();
       });
     });
+
+    it('is invoke-lifecycle when query params change and ignoreQueryParams is false', (done) => {
+      firstInstruction.queryParams = { param: 'foo' };
+      sameAsFirstInstruction.queryParams = { param: 'bar' };
+      sameAsFirstInstruction.options.compareQueryParams = true;
+      firstInstruction.addViewPortInstruction('default', 'ignored', './first', { viewModel: {}});
+
+      step.run(sameAsFirstInstruction, state.next)
+      .then(() => {
+        expect(state.result).toBe(true);
+        expect(sameAsFirstInstruction.plan.default.strategy).toBe('invoke-lifecycle');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
The router would not reload the view if query parameters changed in the same route. We add this behavior to navigation-plan.js and we add the `compareQueryParams` option in order to opt in to this behavior.

Fixes #268.