### PR TITLE
fix(router): router is case sensitive by default

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -68,5 +68,10 @@ interface RouteConfig {
   */
   navModel?: NavModel;
 
+  /**
+  * When true is specified, this route will be case sensitive.
+  */
+  caseSensitive?: boolean;
+
   [x: string]: any;
 }

--- a/src/router.js
+++ b/src/router.js
@@ -245,8 +245,8 @@ export class Router {
     if (path.charAt(0) === '/') {
       path = path.substr(1);
     }
-
-    let state = this._recognizer.add({path: path, handler: config});
+    let caseSensitive = config.caseSensitive === true;
+    let state = this._recognizer.add({path: path, handler: config, caseSensitive: caseSensitive});
 
     if (path) {
       let settings = config.settings;
@@ -257,7 +257,8 @@ export class Router {
       withChild.hasChildRouter = true;
       this._childRecognizer.add({
         path: withChild.route,
-        handler: withChild
+        handler: withChild,
+        caseSensitive: caseSensitive
       });
 
       withChild.navModel = navModel;

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -218,6 +218,22 @@ describe('the router', () => {
         .then(done);
     });
 
+    it('should be case insensitive by default', (done) => {
+      router.configure(config => config.map({ name: 'test', route: 'test/:id', moduleId: './test' }))
+        .then(() => router._createNavigationInstruction('TeSt/123?foo=456'))
+        .then(x => expect(x).toEqual(jasmine.objectContaining({ fragment: 'TeSt/123', queryString: 'foo=456' })))
+        .catch(reason => expect(true).toBeFalsy('should have succeeded'))
+        .then(done);
+    });
+
+    it('should reject when route is case sensitive', (done) => {
+      router.configure(config => config.map({ name: 'test', route: 'Test/:id', moduleId: './test', caseSensitive: true }))
+        .then(() => router._createNavigationInstruction('test/123'))
+        .then(() => expect(true).toBeFalsy('should have rejected'))
+        .catch(reason => expect(reason).toBeTruthy())
+        .then(done);
+    });
+
     describe('catchAllHandler', () => {
       let expectedInstructionShape = jasmine.objectContaining({ config: jasmine.objectContaining({ moduleId: 'test' }) });
 


### PR DESCRIPTION
Router is case sensitive by default, if you need to set some route as case sensitive you can add `caseSensitive: true` property to the route configuration.

in order to close https://github.com/aurelia/router/issues/271