### PR TITLE
feat(router): observables in lifecycle

### DIFF
--- a/src/activation.js
+++ b/src/activation.js
@@ -191,7 +191,7 @@ class SafeSubscription {
   }
   
   unsubscribe() {
-    if(this._subscription) this._subscription.unsubscribe();
+    if(this._subscribed && this._subscription) this._subscription.unsubscribe();
     
     this._subscribed = false;
   }
@@ -204,13 +204,13 @@ function processPotential(obj, resolve, reject) {
   
   if(obj && typeof obj.subscribe === 'function') {
     //an object with a subscribe function should be assumed to be an observable
-    new SafeSubscription(sub => obj.subscribe({
+    return new SafeSubscription(sub => obj.subscribe({
       next() {
         sub.unsubscribe();
         resolve(obj);
       },
-      error(err) {
-        reject(err);
+      error(error) {
+        reject(error);
       }
     }));
   }

--- a/src/activation.js
+++ b/src/activation.js
@@ -190,6 +190,10 @@ class SafeSubscription {
     if(!this._subscribed) this.unsubscribe()
   }
   
+  get subscribed() {
+    return this._subscribed;
+  }
+  
   unsubscribe() {
     if(this._subscribed && this._subscription) this._subscription.unsubscribe();
     
@@ -206,11 +210,22 @@ function processPotential(obj, resolve, reject) {
     //an object with a subscribe function should be assumed to be an observable
     return new SafeSubscription(sub => obj.subscribe({
       next() {
-        sub.unsubscribe();
-        resolve(obj);
+        if(sub.subscribed) {
+          sub.unsubscribe();
+          resolve(obj);
+        }
       },
       error(error) {
-        reject(error);
+        if(sub.subscribed) {
+          sub.unsubscribe();
+          reject(error);
+        }
+      },
+      complete() {
+        if(sub.subscribed) {
+          sub.unsubscribe();
+          resolve(obj);
+        }
       }
     }));
   }


### PR DESCRIPTION
If an object matching an Observable's signature (according to the ECMA proposal) is returned from a custom element's activate hook, the router will wait until at least one piece of data has passed through the Observable to render the component. #328 