### PR TITLE
feat(router): observables in lifecycle

### DIFF
--- a/src/activation.js
+++ b/src/activation.js
@@ -189,7 +189,7 @@ class SafeSubscription {
     this._subscribed = true;
     this._subscription = subscriptionFunc(this);
 
-    if (!this._subscribed) this.unsubscribe()
+    if (!this._subscribed) this.unsubscribe();
   }
 
   get subscribed() {

--- a/src/activation.js
+++ b/src/activation.js
@@ -191,7 +191,7 @@ class SafeSubscription {
   }
   
   unsubscribe() {
-    if(this._subscription) this._subscription.unsubscribe();
+    if(this._subscribed && this._subscription) this._subscription.unsubscribe();
     
     this._subscribed = false;
   }
@@ -204,13 +204,13 @@ function processPotential(obj, resolve, reject) {
   
   if(obj && typeof obj.subscribe === 'function') {
     //an object with a subscribe function should be assumed to be an observable
-    new SafeSubscription(sub => obj.subscribe({
+    return new SafeSubscription(sub => obj.subscribe({
       next() {
         sub.unsubscribe();
         resolve(obj);
       },
-      error(err) {
-        reject(err);
+      error(error) {
+        reject(error);
       }
     }));
   }

--- a/src/activation.js
+++ b/src/activation.js
@@ -190,6 +190,10 @@ class SafeSubscription {
     if(!this._subscribed) this.unsubscribe()
   }
   
+  get subscribed() {
+    return this._subscribed;
+  }
+  
   unsubscribe() {
     if(this._subscribed && this._subscription) this._subscription.unsubscribe();
     
@@ -206,11 +210,22 @@ function processPotential(obj, resolve, reject) {
     //an object with a subscribe function should be assumed to be an observable
     return new SafeSubscription(sub => obj.subscribe({
       next() {
-        sub.unsubscribe();
-        resolve(obj);
+        if(sub.subscribed) {
+          sub.unsubscribe();
+          resolve(obj);
+        }
       },
       error(error) {
-        reject(error);
+        if(sub.subscribed) {
+          sub.unsubscribe();
+          reject(error);
+        }
+      },
+      complete() {
+        if(sub.subscribed) {
+          sub.unsubscribe();
+          resolve(obj);
+        }
       }
     }));
   }

--- a/src/activation.js
+++ b/src/activation.js
@@ -180,6 +180,8 @@ function shouldContinue(output, router: Router) {
   return output;
 }
 
+//wraps a subscription, allowing unsubscribe calls even if
+//the first value comes synchronously
 class SafeSubscription {
   //if this were TypeScript, subscriptionFunc would be of type
   //(sub: SafeSubscription) => Subscription

--- a/src/activation.js
+++ b/src/activation.js
@@ -181,22 +181,22 @@ function shouldContinue(output, router: Router) {
 }
 
 class SafeSubscription {
-  //if this were TypeScript, subscriptionFunc would be of type 
+  //if this were TypeScript, subscriptionFunc would be of type
   //(sub: SafeSubscription) => Subscription
   constructor(subscriptionFunc) {
     this._subscribed = true;
     this._subscription = subscriptionFunc(this);
-    
-    if(!this._subscribed) this.unsubscribe()
+
+    if (!this._subscribed) this.unsubscribe()
   }
-  
+
   get subscribed() {
     return this._subscribed;
   }
-  
+
   unsubscribe() {
-    if(this._subscribed && this._subscription) this._subscription.unsubscribe();
-    
+    if (this._subscribed && this._subscription) this._subscription.unsubscribe();
+
     this._subscribed = false;
   }
 }
@@ -205,24 +205,24 @@ function processPotential(obj, resolve, reject) {
   if (obj && typeof obj.then === 'function') {
     return Promise.resolve(obj).then(resolve).catch(reject);
   }
-  
-  if(obj && typeof obj.subscribe === 'function') {
+
+  if (obj && typeof obj.subscribe === 'function') {
     //an object with a subscribe function should be assumed to be an observable
     return new SafeSubscription(sub => obj.subscribe({
       next() {
-        if(sub.subscribed) {
+        if (sub.subscribed) {
           sub.unsubscribe();
           resolve(obj);
         }
       },
       error(error) {
-        if(sub.subscribed) {
+        if (sub.subscribed) {
           sub.unsubscribe();
           reject(error);
         }
       },
       complete() {
-        if(sub.subscribed) {
+        if (sub.subscribed) {
           sub.unsubscribe();
           resolve(obj);
         }


### PR DESCRIPTION
feat(router): observables in lifecycle

When an Observabe (or something approximating one, as per the ECMA proposal) is returned from the activate hook, the router will wait until at least one value has moved through the Observable (or if the Observable completes while empty) before rendering the view.

Implements #336 