### PR TITLE
fix(router): change refresh navigation to check config for static href not nav model href

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -339,7 +339,7 @@ export class Router {
 
     for (let i = 0, length = nav.length; i < length; i++) {
       let current = nav[i];
-      if (!current.href) {
+      if (!current.config.href) {
         current.href = _createRootedPath(current.relativeHref, this.baseUrl, this.history._hasPushState);
       }
     }

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -383,4 +383,34 @@ describe('the router', () => {
       resolve();
     });
   });
+
+  describe('refreshNavigation', () => {
+    let staticHref;
+
+    beforeEach((done) => {
+      staticHref = '#/a/static/href';
+      router.baseUrl = 'initial-root';
+
+      router.configure(config => config.map([
+        { name: 'dynamic', route: 'dynamic', moduleId: 'dynamic', nav: true },
+        { name: 'static', route: 'static', moduleId: 'static', href: staticHref, nav: true }])).then(() => {
+        router.refreshNavigation();
+        done();
+      });
+    })
+
+    it('updates a dynamic href ', () => {
+      router.baseUrl = 'updated-root';
+      router.refreshNavigation();
+
+      expect(router.navigation[0].href).toEqual('#/updated-root/dynamic');
+    });
+
+    it('updates a dynamic href ', () => {
+      router.baseUrl = 'updated-root';
+      router.refreshNavigation();
+
+      expect(router.navigation[1].href).toEqual(staticHref);
+    });
+  });
 });

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -394,10 +394,10 @@ describe('the router', () => {
       router.configure(config => config.map([
         { name: 'dynamic', route: 'dynamic', moduleId: 'dynamic', nav: true },
         { name: 'static', route: 'static', moduleId: 'static', href: staticHref, nav: true }])).then(() => {
-        router.refreshNavigation();
-        done();
-      });
-    })
+          router.refreshNavigation();
+          done();
+        });
+    });
 
     it('updates a dynamic href ', () => {
       router.baseUrl = 'updated-root';

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -406,7 +406,7 @@ describe('the router', () => {
       expect(router.navigation[0].href).toEqual('#/updated-root/dynamic');
     });
 
-    it('updates a dynamic href ', () => {
+    it('respects a static href ', () => {
       router.baseUrl = 'updated-root';
       router.refreshNavigation();
 


### PR DESCRIPTION
`router.refreshNavigation` should update the href of navigation model when route changes. Static routes (defined in config) do not need to update this property. The check for a static href was looking at the nav href instead of the config href.

closes aurelia/router#246