### PR TITLE
fix(router): ensure routes have distinct names

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -226,7 +226,7 @@ export class Router {
   * @param navModel The [[NavModel]] to use for the route. May be omitted for single-pattern routes.
   */
   addRoute(config: RouteConfig, navModel?: NavModel): void {
-    validateRouteConfig(config);
+    validateRouteConfig(config, this.routes);
 
     if (!('viewPorts' in config) && !config.navigationStrategy) {
       config.viewPorts = {
@@ -425,7 +425,7 @@ export class Router {
       .then(c => typeof c === 'string' ? { moduleId: c } : c)
       .then(c => {
         c.route = instruction.params.path;
-        validateRouteConfig(c);
+        validateRouteConfig(c, this.routes);
 
         if (!c.navModel) {
           c.navModel = this.createNavModel(c);
@@ -436,7 +436,7 @@ export class Router {
   }
 }
 
-function validateRouteConfig(config: RouteConfig): void {
+function validateRouteConfig(config: RouteConfig, routes: Array<Object>): void {
   if (typeof config !== 'object') {
     throw new Error('Invalid Route Config');
   }
@@ -444,6 +444,13 @@ function validateRouteConfig(config: RouteConfig): void {
   if (typeof config.route !== 'string') {
     let name = config.name || '(no name)';
     throw new Error('Invalid Route Config for "' + name + '": You must specify a "route:" pattern.');
+  }
+
+  for (let i = 0, ii = routes.length; i < ii; ++i) {
+    let route = routes[i];
+    if (route.name === config.name) {
+      throw new Error('Routes must contain distinct names');
+    }
   }
 
   if (!('redirect' in config || config.moduleId || config.navigationStrategy || config.viewPorts)) {

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -67,6 +67,18 @@ describe('the router', () => {
         'number2': { moduleId: 'test2' }
       }})).not.toThrow();
     });
+
+    it('throws an error if routes do not have distinct names', () => {
+      const configs = [
+        { route: '', moduleId: './test', name: 'name1' },
+        { route: '/test1', moduleId: './test1', name: 'name1' }
+      ];
+
+      router.addRoute(configs[0]);
+      expect(router.hasRoute('name1'));
+      expect(() => router.addRoute(configs[0])).toThrow();
+      expect(router.routes.length).toBe(1);
+    });
   });
 
   describe('generate', () => {


### PR DESCRIPTION
This is in reference to #366.

Router will throw an error if a route with the same name in addRoute