### PR TITLE
make router have the responsibility of resolving the location of the …

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
       "aurelia-history": "^1.0.0",
       "aurelia-logging": "^1.0.0",
       "aurelia-path": "^1.0.0",
+      "aurelia-metadata": "^1.0.0",
       "aurelia-route-recognizer": "^1.0.0"
     },
     "dependencies": {

--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,8 @@ import {
   _createRootedPath,
   _resolveUrl} from './util';
 import {RouteConfig} from './interfaces';
+import {relativeToFile} from 'aurelia-path';
+import {Origin} from 'aurelia-metadata';
 
 /**
 * The primary class responsible for handling routing and navigation.
@@ -133,6 +135,21 @@ export class Router {
       this.isConfigured = true;
       this._resolveConfiguredPromise();
     });
+  }
+
+  /**
+  * Finds the locations of a view model.
+  * By default it uses the moduleId as a path relative to the location of the router itself
+  * You can subclass the Router and provide a custom way to resolve view model locations, such
+  * as loading the file from a module in /node_modules
+  *
+  * Used by TemplatingRouteLoader in route-loader
+  *
+  * @param the route configuration
+  * @returns {string} The file location of the view model
+  */
+  viewModelLocation(config) {
+      return relativeToFile(config.moduleId, Origin.get(this.container.viewModel.constructor).moduleId);
   }
 
   /**


### PR DESCRIPTION
Works in conjunction with https://github.com/aurelia/templating-router/pull/35

Allows Router to provide strategy for how to find a viewModel, no longer being limited/hardcoded to the path relative to the router file.

A use case would be f.ex to have reusable components installed in `src/resources/components`.
It quickly becomes ugly and tiresome to prepend with the full path.

`{ route: 'contacts',  moduleId: 'resources/components/contact-detail', name:'contacts' }`

Better then to subclass the `Router` with a different. `viewModelLocation` strategy, perhaps using a custom attribute on the route to determine how to find the route module.

`{ route: 'contacts',  moduleId: 'contact-detail',  name:'contacts', component: true }`

Would also be preferable to avoid having all the components in a flat structure. How about a folder per viewModel as an alternative. Again a custom router strategy could allow for this while keeping the route configuration clean.

```bash
components/
  contact-detail/
     contact-detail.html
     contact-detail.ts
  contact-list/
     ...
```

