### PR TITLE
RouteConfig interface doesn't contain auth property

### DIFF
--- a/doc/article/en-US/router-configuration.md
+++ b/doc/article/en-US/router-configuration.md
@@ -422,7 +422,7 @@ A pipeline step must be an object that contains a `run(navigationInstruction, ne
     }
 
     class AuthorizeStep {
-      run(navigationInstruction: NavigationInstruction, next: Function): Promise<any> {
+      run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
         if (navigationInstruction.getAllInstructions().some(i => (<any>i.config).auth)) {
           var isLoggedIn = //insert magic here;
           if (!isLoggedIn) {

--- a/doc/article/en-US/router-configuration.md
+++ b/doc/article/en-US/router-configuration.md
@@ -423,7 +423,7 @@ A pipeline step must be an object that contains a `run(navigationInstruction, ne
 
     class AuthorizeStep {
       run(navigationInstruction: NavigationInstruction, next: Function): Promise<any> {
-        if (navigationInstruction.getAllInstructions().some(i => i.config.auth)) {
+        if (navigationInstruction.getAllInstructions().some(i => (<any>i.config).auth)) {
           var isLoggedIn = //insert magic here;
           if (!isLoggedIn) {
             return next.cancel(new Redirect('login'));


### PR DESCRIPTION
the router :: RouteConfig interface doesn't contain the auth property, therefore giving an error in TypeScript. Added a cast to any to correct this, as you probably want to have a dedicated property for this stuff instead of adding it to the settings object, which would pollute things a bit.