### PR TITLE
Adjust documentation and interface for TypeScript Authentication

### DIFF
--- a/doc/article/en-US/router-configuration.md
+++ b/doc/article/en-US/router-configuration.md
@@ -422,7 +422,7 @@ A pipeline step must be an object that contains a `run(navigationInstruction, ne
     }
 
     class AuthorizeStep {
-      run(navigationInstruction: NavigationInstruction, next: Function): Promise<any> {
+      run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
         if (navigationInstruction.getAllInstructions().some(i => i.config.auth)) {
           var isLoggedIn = //insert magic here;
           if (!isLoggedIn) {

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -79,6 +79,11 @@ interface RouteConfig {
   caseSensitive?: boolean;
 
   /**
+  * When true is specified, this route will be authenticated using the optional Auth pipeline.
+  */
+  auth?: boolean;
+
+  /**
   * Add to specify an activation strategy if it is always the same and you do not want that
   * to be in your view-model code. Available values are 'replace' and 'invoke-lifecycle'.
   */


### PR DESCRIPTION
fix(TypeScript interface): Added auth property to match code sample.

The documentation refers to a method signature showing "next" described
as "Function" when an interface was introduced to wrap it and make sure
it could be cancelled.

There's also an update to the interfaces to place the "auth" property on
the RouteConfig so that the code sample works.

Fixes issues: #349 #265   -- they're closed, but I got this bug in most recent version.