### PR TITLE
Fix wrong attribute on router-view example

### DIFF
--- a/doc/article/en-US/router-configuration.md
+++ b/doc/article/en-US/router-configuration.md
@@ -626,7 +626,7 @@ Similar to MVC-style master/layout pages, Aurelia allows configuration of multip
   <source-code lang="HTML">
     <template>
       <div class="page-host">
-        <router-view layout="views/layout-default.html"></router-view>
+        <router-view layout-view="views/layout-default.html"></router-view>
       </div>
     </template>
   </source-code>


### PR DESCRIPTION
Current documentation points to the layout property on RouterView (which does not exist),
this fixes that problem.