### PR TITLE
Publishes an inner instruction resolve

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -199,9 +199,9 @@ function processResult(instruction, result, instructionCount, router) {
 function resolveInstruction(instruction, result, isInnerInstruction, router) {
   instruction.resolve(result);
 
+  let eventArgs = { instruction, result };
   if (!isInnerInstruction) {
     router.isNavigating = false;
-    let eventArgs = { instruction, result };
     let eventName;
 
     if (result.output instanceof Error) {
@@ -216,6 +216,8 @@ function resolveInstruction(instruction, result, isInnerInstruction, router) {
 
     router.events.publish(`router:navigation:${eventName}`, eventArgs);
     router.events.publish('router:navigation:complete', eventArgs);
+  } else {
+    router.events.publish('router:navigation:innerInstruction:resolve', eventArgs);
   }
 
   return result;

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -217,7 +217,7 @@ function resolveInstruction(instruction, result, isInnerInstruction, router) {
     router.events.publish(`router:navigation:${eventName}`, eventArgs);
     router.events.publish('router:navigation:complete', eventArgs);
   } else {
-    router.events.publish('router:navigation:innerInstruction:resolve', eventArgs);
+    router.events.publish('router:navigation:child:complete', eventArgs);
   }
 
   return result;


### PR DESCRIPTION
I have a route that simply redirects to a different module, but I wasn't receiving any published events from the router with the instruction details.

This allows me to hook in on the instruction that is being re-directed to without having to worry about why there is a conditional on the other events that get published.
