### PR TITLE
Syntax error when using the example provided in docs

### DIFF
--- a/doc/article/en-US/router-configuration.md
+++ b/doc/article/en-US/router-configuration.md
@@ -682,8 +682,8 @@ Similar to MVC-style master/layout pages, Aurelia allows configuration of multip
         };
         config.map([
           { route: 'home', name: 'home', moduleId: 'home/index' },
-          { route: 'login', name: 'login', moduleId: 'login/index', layoutView = 'views/layout-login.html' },
-          { route: 'users', name: 'users', moduleId: 'users/index', layoutViewModel = 'views/model', layoutModel: model }
+          { route: 'login', name: 'login', moduleId: 'login/index', layoutView: 'views/layout-login.html' },
+          { route: 'users', name: 'users', moduleId: 'users/index', layoutViewModel: 'views/model', layoutModel: model }
         ]);
       }
     }


### PR DESCRIPTION
fix router/doc/article/en-US/router-configuration.md: unexpected token when building the module