### PR TITLE
doc(typescript): fix mapUnknownRoutes Typescript compile error

### DIFF
--- a/doc/article/en-US/router-configuration.md
+++ b/doc/article/en-US/router-configuration.md
@@ -301,8 +301,7 @@ The function passed to `mapUnknownRoutes()` has to return:
         config.title = 'Aurelia';
 
         var handleUnknownRoutes = (instruction) => {
-            // return 'not-found';
-            return { moduleId: 'not-found' };
+            return { route: 'not-found', moduleId: 'not-found' };
         }
 
         config.mapUnknownRoutes(handleUnknownRoutes);
@@ -318,7 +317,7 @@ The function passed to `mapUnknownRoutes()` has to return:
 
   </source-code>
   <source-code lang="TypeScript">
-    import {RouterConfiguration, NavigationInstruction, Router} from 'aurelia-router';
+    import {RouterConfiguration, NavigationInstruction, Router, RouteConfig} from 'aurelia-router';
 
     export class App {
       configureRouter(config: RouterConfiguration, router: Router): void {
@@ -326,9 +325,8 @@ The function passed to `mapUnknownRoutes()` has to return:
 
         config.title = 'Aurelia';
 
-        let handleUnknownRoutes = (instruction: NavigationInstruction): {moduleId: string} => {
-            // return 'not-found';
-            return { moduleId: 'not-found' };
+        let handleUnknownRoutes = (instruction: NavigationInstruction): RouteConfig => {
+            return { route: 'not-found', moduleId: 'not-found' };
         }
 
         config.mapUnknownRoutes(handleUnknownRoutes);


### PR DESCRIPTION
The TypeScript examples that shows how to setup a function to map unknown routes has an error in it. At the moment, it returns an object containing a `moduleId` string. However, this leads to a compile error, which makes sense if we examine the typings:

``` typescript
mapUnknownRoutes(config: string | RouteConfig | ((instruction: NavigationInstruction) => string | RouteConfig | Promise<string | RouteConfig>)): RouterConfiguration;
```

The specific function overload used is expected to return a `string`, not an object. The ES6 example returns the same object, so either the typings are wrong or there is also a bug in the ES6 example.
