### PR TITLE
feat(router) add navigation flags

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -1,10 +1,10 @@
 import * as LogManager from 'aurelia-logging';
-import { Container } from 'aurelia-dependency-injection';
-import { History } from 'aurelia-history';
-import { Router } from './router';
-import { PipelineProvider } from './pipeline-provider';
-import { isNavigationCommand } from './navigation-commands';
-import { EventAggregator } from 'aurelia-event-aggregator';
+import {Container} from 'aurelia-dependency-injection';
+import {History} from 'aurelia-history';
+import {Router} from './router';
+import {PipelineProvider} from './pipeline-provider';
+import {isNavigationCommand} from './navigation-commands';
+import {EventAggregator} from 'aurelia-event-aggregator';
 
 const logger = LogManager.getLogger('app-router');
 
@@ -62,7 +62,7 @@ export class AppRouter extends Router {
       if ('configureRouter' in viewModel) {
         if (!this.isConfigured) {
           let resolveConfiguredPromise = this._resolveConfiguredPromise;
-          this._resolveConfiguredPromise = () => { };
+          this._resolveConfiguredPromise = () => {};
           return this.configure(config => viewModel.configureRouter(config, this))
             .then(() => {
               this.activate();

--- a/src/router.js
+++ b/src/router.js
@@ -48,6 +48,36 @@ export class Router {
   isExplicitNavigationBack: boolean;
 
   /**
+  * True if the [[Router]] is navigating into the app for the first time in the browser session.
+  */
+  isNavigatingFirst: boolean;
+
+  /**
+  * True if the [[Router]] is navigating to a page instance not in the browser session history.
+  */
+  isNavigatingNew: boolean;
+
+  /**
+  * True if the [[Router]] is navigating forward in the browser session history.
+  */
+  isNavigatingForward: boolean;
+
+  /**
+  * True if the [[Router]] is navigating back in the browser session history.
+  */
+  isNavigatingBack: boolean;
+
+  /**
+  * True if the [[Router]] is navigating due to a browser refresh.
+  */
+  isNavigatingRefresh: boolean;
+
+  /**
+  * The currently active navigation tracker.
+  */
+  currentNavigationTracker: number;
+
+  /**
   * The navigation models for routes that specified [[RouteConfig.nav]].
   */
   navigation: NavModel[];
@@ -98,6 +128,11 @@ export class Router {
     this.isNavigating = false;
     this.isExplicitNavigation = false;
     this.isExplicitNavigationBack = false;
+    this.isNavigatingFirst = false;
+    this.isNavigatingNew = false;
+    this.isNavigatingRefresh = false;
+    this.isNavigatingForward = false;
+    this.isNavigatingBack = false;
     this.navigation = [];
     this.currentInstruction = null;
     this._fallbackOrder = 100;

--- a/test/app-router.spec.js
+++ b/test/app-router.spec.js
@@ -9,6 +9,10 @@ class MockHistory extends History {
   deactivate() {}
   navigate() {}
   navigateBack() {}
+  setState(key, value) {}
+  getState(key) {
+    return null;
+  }
 }
 
 class MockLoader extends RouteLoader {

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -13,6 +13,10 @@ class MockHistory extends History {
   getAbsoluteRoot() {
     return absoluteRoot;
   }
+  setState(key, value) {}
+  getState(key) {
+    return null;
+  }
 }
 
 describe('the router', () => {


### PR DESCRIPTION
The added properties allows deciding on behaviour during the routing lifecycle based on user navigation choices.

Depending on PR aurelia/history-browser/page-state.
Closes aurelia/router#436.