### PR TITLE
doc(pipeline): fix return type

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -45,7 +45,7 @@ interface PipelineStep {
    * @param instruction The navigation instruction.
    * @param next The next step in the pipeline.
    */
-  run(instruction: NavigationInstruction, next: Next): void;
+  run(instruction: NavigationInstruction, next: Next): Promise<any>;
 }
 
 /**


### PR DESCRIPTION
Change PipelineStep.prototype.run return type to Promise because next(), next.complete() return Promise.