### PR TITLE
chore(empty-routes): fix child urls with emptys

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -161,19 +161,29 @@ export class NavigationInstruction {
   * Gets the instruction's base URL, accounting for wildcard route parameters.
   */
   getBaseUrl(): string {
+    let fragment = this.fragment;
+
+    if (fragment === '') {
+      let nonEmptyRoute = this.router.routes.find(route => {
+        return route.name === this.config.name &&
+          route.route !== '';
+      });
+      fragment = nonEmptyRoute.route;
+    }
+
     if (!this.params) {
-      return this.fragment;
+      return fragment;
     }
 
     let wildcardName = this.getWildCardName();
     let path = this.params[wildcardName] || '';
 
     if (!path) {
-      return this.fragment;
+      return fragment;
     }
 
     path = encodeURI(path);
-    return this.fragment.substr(0, this.fragment.lastIndexOf(path));
+    return fragment.substr(0, fragment.lastIndexOf(path));
   }
 
   _commitChanges(waitToSwap: boolean) {

--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -168,7 +168,9 @@ export class NavigationInstruction {
         return route.name === this.config.name &&
           route.route !== '';
       });
-      fragment = nonEmptyRoute.route;
+      if (nonEmptyRoute) {
+        fragment = nonEmptyRoute.route;
+      }
     }
 
     if (!this.params) {

--- a/test/navigation-instruction.spec.js
+++ b/test/navigation-instruction.spec.js
@@ -1,0 +1,95 @@
+import {History} from 'aurelia-history';
+import {Container} from 'aurelia-dependency-injection';
+import {AppRouter} from '../src/app-router';
+import {PipelineProvider} from '../src/pipeline-provider';
+import {NavigationInstruction} from '../src/navigation-instruction';
+
+let absoluteRoot = 'http://aurelia.io/docs/';
+
+class MockHistory extends History {
+  activate() {}
+  deactivate() {}
+  navigate() {}
+  navigateBack() {}
+  getAbsoluteRoot() {
+    return absoluteRoot;
+  }
+}
+
+describe('NavigationInstruction', () => {
+  let router;
+  let history;
+
+  beforeEach(() => {
+    history = new MockHistory();
+    router = new AppRouter(new Container(), history, new PipelineProvider(new Container()));
+  });
+
+  describe('getBaseUrl()', () => {
+    let child;
+    const parentRouteName = 'parent';
+    const childRouteName = 'child';
+
+    beforeEach(() => {
+      router.addRoute({
+        name: parentRouteName,
+        route: '',
+        moduleId: parentRouteName
+      });
+      router.addRoute({
+        name: parentRouteName,
+        route: parentRouteName,
+        moduleId: parentRouteName
+      });
+      child = router.createChild(new Container());
+      child.addRoute({
+        name: childRouteName,
+        route: childRouteName,
+        moduleId: childRouteName
+      });
+    });
+
+    it('should return the raw fragment when no params exist', (done) => {
+      router._createNavigationInstruction(parentRouteName).then(instruction => {
+        expect(instruction.getBaseUrl()).toBe(parentRouteName);
+        done();
+      });
+    });
+
+    it('should return the raw fragment when no wildcard exists', (done) => {
+      router._createNavigationInstruction(parentRouteName).then(instruction => {
+        instruction.params = { fake: 'fakeParams' };
+        expect(instruction.getBaseUrl()).toBe(parentRouteName);
+        done();
+      });
+    });
+
+    describe('when using an empty parent route', () => {
+      fit('should return the non-empty matching parent route', (done) => {
+        router._createNavigationInstruction('').then(parentInstruction => {
+          router.currentInstruction = parentInstruction;
+          router._refreshBaseUrl();
+          child._createNavigationInstruction(childRouteName).then(instruction => {
+            child._refreshBaseUrl();
+            expect(child.baseUrl).toBe(parentRouteName);
+            done();
+          });
+        });
+      });
+    });
+
+    describe('when using an named parent route', () => {
+      it('should return the non-empty matching parent route', (done) => {
+        router._createNavigationInstruction(parentRouteName).then(parentInstruction => {
+          router.currentInstruction = parentInstruction;
+          router._refreshBaseUrl();
+          child._createNavigationInstruction(childRouteName).then(instruction => {
+            child._refreshBaseUrl();
+            expect(child.baseUrl).toBe(parentRouteName);
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/navigation-instruction.spec.js
+++ b/test/navigation-instruction.spec.js
@@ -65,7 +65,7 @@ describe('NavigationInstruction', () => {
     });
 
     describe('when using an empty parent route', () => {
-      fit('should return the non-empty matching parent route', (done) => {
+      it('should return the non-empty matching parent route', (done) => {
         router._createNavigationInstruction('').then(parentInstruction => {
           router.currentInstruction = parentInstruction;
           router._refreshBaseUrl();


### PR DESCRIPTION
Fixes #27

When a child router is checking for a parents baseUrl it does not take
in to account that the parent may be routing to the empty route.  This
PR adds a spec to cover that scenario and a basic implementation.