### PR TITLE
feat(viewport): add viewport name to life cycle arguments

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -122,13 +122,14 @@ export class NavigationInstruction {
   * Adds a viewPort instruction.
   */
   addViewPortInstruction(viewPortName: string, strategy: string, moduleId: string, component: any): any {
+    const config = Object.assign({}, this.lifecycleArgs[1], { currentViewPort: viewPortName });
     let viewportInstruction = this.viewPortInstructions[viewPortName] = {
       name: viewPortName,
       strategy: strategy,
       moduleId: moduleId,
       component: component,
       childRouter: component.childRouter,
-      lifecycleArgs: this.lifecycleArgs.slice()
+      lifecycleArgs: [].concat(this.lifecycleArgs[0], config, this.lifecycleArgs[2])
     };
 
     return viewportInstruction;

--- a/test/activation.spec.js
+++ b/test/activation.spec.js
@@ -1,8 +1,10 @@
 import {
   CanDeactivatePreviousStep,
-  CanActivateNextStep
+  CanActivateNextStep,
+  ActivateNextStep
 } from '../src/activation';
 import {activationStrategy} from '../src/navigation-plan';
+import {NavigationInstruction} from '../src/navigation-instruction';
 import {createPipelineState} from './test-util';
 
 describe('activation', () => {
@@ -182,6 +184,33 @@ describe('activation', () => {
 
       step.run(instruction, state.next);
       expect(state.rejection).toBeTruthy();
+    });
+  });
+
+  describe('ActivateNextStep', () => {
+    let step;
+    let state;
+
+    beforeEach(() => {
+      step = new ActivateNextStep();
+    });
+
+    it('should pass current viewport name to activate', (done) => {
+      const instruction = new NavigationInstruction({
+        plan: {
+          "my-view-port": { strategy: activationStrategy.invokeLifecycle }
+        }
+      });
+
+      const viewModel = {
+        activate(params, config, instruction) {
+          expect(config.currentViewPort).toBe('my-view-port');
+          done();
+        }
+      }
+    
+      instruction.addViewPortInstruction('my-view-port', 'ignored', 'ignored', { viewModel });
+      step.run(instruction);
     });
   });
 });


### PR DESCRIPTION
Consider the following scenario:

The same view-model can be reused in different view ports (for example in a two-column layout). The rendering might slightly differ depending on which view port is it being rendered in. How should the view-model access this information?

Added viewport's name to config object being sent to `activate` / `deactivate`