### PR TITLE
fix(router): invoke deactivate method on child modules

### DIFF
--- a/src/activation.js
+++ b/src/activation.js
@@ -58,6 +58,7 @@ function findDeactivatable(plan, callbackName, list: Array<Object> = []): Array<
   for (let viewPortName in plan) {
     let viewPortPlan = plan[viewPortName];
     let prevComponent = viewPortPlan.prevComponent;
+    let canDeactivate = callbackName === "canDeactivate";
 
     if ((viewPortPlan.strategy === activationStrategy.invokeLifecycle ||
         viewPortPlan.strategy === activationStrategy.replace) &&
@@ -69,7 +70,9 @@ function findDeactivatable(plan, callbackName, list: Array<Object> = []): Array<
       }
     }
 
-    if (viewPortPlan.childNavigationInstruction) {
+    if ((viewPortPlan.childNavigationInstruction && canDeactivate) ||
+        (viewPortPlan.childNavigationInstruction && !canDeactivate &&
+        !prevComponent)) {
       findDeactivatable(viewPortPlan.childNavigationInstruction.plan, callbackName, list);
     } else if (prevComponent) {
       addPreviousDeactivatable(prevComponent, callbackName, list);


### PR DESCRIPTION
This PR adds additional logic to determine the current step and whether to prioritize prevComponent or childNavigationInstruction

The 'canDeactivate' step should prioritize child navigation instructions whereas the 'deactivate' step should prioritize the previous component which will contain the additional child modules.

I had originally swapped the statements around like this:
```
    if (prevComponent) {
      addPreviousDeactivatable(prevComponent, callbackName, list);
    } else if (viewPortPlan.childNavigationInstruction) {
      findDeactivatable(viewPortPlan.childNavigationInstruction.plan, callbackName, list);
    }
```
But this caused one of the canDeactivate tests to fail. 

This PR addresses issues: 
[#132](https://github.com/aurelia/router/issues/132) 
[#411](https://github.com/aurelia/router/issues/411)