### PR TITLE
fix(router): getBaseUrl() to return correct URL for encodable chars

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -162,7 +162,7 @@ export class NavigationInstruction {
   * Gets the instruction's base URL, accounting for wildcard route parameters.
   */
   getBaseUrl(): string {
-    let fragment = this.fragment;
+    let fragment = decodeURI(this.fragment);
 
     if (fragment === '') {
       let nonEmptyRoute = this.router.routes.find(route => {
@@ -175,7 +175,7 @@ export class NavigationInstruction {
     }
 
     if (!this.params) {
-      return fragment;
+      return encodeURI(fragment);
     }
 
     let wildcardName = this.getWildCardName();
@@ -185,8 +185,7 @@ export class NavigationInstruction {
       return fragment;
     }
 
-    path = encodeURI(path);
-    return fragment.substr(0, fragment.lastIndexOf(path));
+    return encodeURI(fragment.substr(0, fragment.lastIndexOf(path)));
   }
 
   _commitChanges(waitToSwap: boolean) {


### PR DESCRIPTION
This addresses issues: #435 and #486 

`fragment` may or may not be encoded but `path` will always be decoded. In order to compare `fragment` and `path` - `fragment` has to be decoded first.

This will cover any use-cases where fragment is not encoded, partially encoded or fully encoded.

This will affect `router.baseUrl` which will now be encoded. It will also affect the `href` parameter in the `router.navigation` array.

This means it may not be exactly the same as navigationInstruction.fragment for any of the routes if the URL isn't fully encoded to begin with. 