### PR TITLE
fix(navigation-instruction): getBaseUrl() to return correct URL for encodable chars

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -182,7 +182,7 @@ export class NavigationInstruction {
     let path = this.params[wildcardName] || '';
 
     if (!path) {
-      return fragment;
+      return encodeURI(fragment);
     }
 
     return encodeURI(fragment.substr(0, fragment.lastIndexOf(path)));

--- a/test/navigation-instruction.spec.js
+++ b/test/navigation-instruction.spec.js
@@ -76,23 +76,36 @@ describe('NavigationInstruction', () => {
       });
     });
 
-    it('should handle encoded uris properly', (done) => {
-      router._createNavigationInstruction('parent/parent 1').then(instruction => {
-        expect(instruction.getBaseUrl()).toBe('parent/parent%201');
-        done();
+    describe('when a uri contains spaces', () => {
+
+      it('should handle an encoded uri', (done) => {
+        router._createNavigationInstruction('parent/parent%201').then(instruction => {
+          expect(instruction.getBaseUrl()).toBe('parent/parent%201');;
+          done();
+        });
       });
-      router._createNavigationInstruction('parent/parent%201').then(instruction => {
-        expect(instruction.getBaseUrl()).toBe('parent/parent%201');
-        done();
+
+      it('should encode the uri', (done) => {
+        router._createNavigationInstruction('parent/parent 1').then(instruction => {
+          expect(instruction.getBaseUrl()).toBe('parent/parent%201');
+          done();
+        });
       });
-      router._createNavigationInstruction('parent/parent 1/child/child 1').then(instruction => {
-        expect(instruction.getBaseUrl()).toBe('parent/parent%201/');
-        done();
+
+      it('should identify encoded fragments', (done) => {
+        router._createNavigationInstruction('parent/parent%201/child/child%201').then(instruction => {
+          expect(instruction.getBaseUrl()).toBe('parent/parent%201/');
+          done();
+        });
       });
-      router._createNavigationInstruction('parent/parent%201/child/child%201').then(instruction => {
-        expect(instruction.getBaseUrl()).toBe('parent/parent%201/');
-        done();
+
+      it('should identify fragments and encode them', (done) => { 
+        router._createNavigationInstruction('parent/parent 1/child/child 1').then(instruction => {
+          expect(instruction.getBaseUrl()).toBe('parent/parent%201/');
+          done();
+        });
       });
+
     });
 
     describe('when using an empty parent route', () => {

--- a/test/navigation-instruction.spec.js
+++ b/test/navigation-instruction.spec.js
@@ -28,7 +28,9 @@ describe('NavigationInstruction', () => {
   describe('getBaseUrl()', () => {
     let child;
     const parentRouteName = 'parent';
+    const parentParamRouteName = 'parent/:parent';
     const childRouteName = 'child';
+    const childParamRouteName = 'child/:child';
 
     beforeEach(() => {
       router.addRoute({
@@ -41,10 +43,20 @@ describe('NavigationInstruction', () => {
         route: parentRouteName,
         moduleId: parentRouteName
       });
+      router.addRoute({
+        name: parentParamRouteName,
+        route: parentParamRouteName,
+        moduleId: parentRouteName,
+      })
       child = router.createChild(new Container());
       child.addRoute({
         name: childRouteName,
         route: childRouteName,
+        moduleId: childRouteName
+      });
+      child.addRoute({
+        name: childParamRouteName,
+        route: childParamRouteName,
         moduleId: childRouteName
       });
     });
@@ -60,6 +72,25 @@ describe('NavigationInstruction', () => {
       router._createNavigationInstruction(parentRouteName).then(instruction => {
         instruction.params = { fake: 'fakeParams' };
         expect(instruction.getBaseUrl()).toBe(parentRouteName);
+        done();
+      });
+    });
+
+    it('should handle encoded uris properly', (done) => {
+      router._createNavigationInstruction('parent/parent 1').then(instruction => {
+        expect(instruction.getBaseUrl()).toBe('parent/parent%201');
+        done();
+      });
+      router._createNavigationInstruction('parent/parent%201').then(instruction => {
+        expect(instruction.getBaseUrl()).toBe('parent/parent%201');
+        done();
+      });
+      router._createNavigationInstruction('parent/parent 1/child/child 1').then(instruction => {
+        expect(instruction.getBaseUrl()).toBe('parent/parent%201/');
+        done();
+      });
+      router._createNavigationInstruction('parent/parent%201/child/child%201').then(instruction => {
+        expect(instruction.getBaseUrl()).toBe('parent/parent%201/');
         done();
       });
     });


### PR DESCRIPTION
This addresses issues #435 and #486 and extends pull request https://github.com/aurelia/router/pull/497.

fragment may or may not be encoded but path will always be decoded. In order to compare fragment and path - fragment has to be decoded first.

This will cover any use-cases where fragment is not encoded, partially encoded or fully encoded.

This will affect router.baseUrl which will now be encoded. It will also affect the href parameter in the router.navigation array.

This means it may not be exactly the same as navigationInstruction.fragment for any of the routes if the URL isn't fully encoded to begin with.