### PR TITLE
test(activation.spec): Remove obsolete activation test

### DIFF
--- a/test/activation.spec.js
+++ b/test/activation.spec.js
@@ -94,28 +94,6 @@ describe('activation', () => {
       expect(state.rejection).toBeTruthy();
     });
 
-    describe('with a childNavigationInstruction', () => {
-      it('should return true when child is true', () => {
-        let viewPort = viewPortFactory(() => (true));
-        let instruction = { plan: { first: viewPort } };
-
-        viewPort.childNavigationInstruction = { plan: { first: viewPortFactory(() => (true)) } };
-
-        step.run(instruction, state.next);
-        expect(state.result).toBe(true);
-      });
-
-      it('should cancel when child is false', () => {
-        let viewPort = viewPortFactory(() => (true));
-        let instruction = { plan: { first: viewPort } };
-
-        viewPort.childNavigationInstruction = { plan: { first: viewPortFactory(() => (false)) } };
-
-        step.run(instruction, state.next);
-        expect(state.rejection).toBeTruthy();
-      });
-    });
-
     describe('with router and currentInstruction', ()=> {
       let viewModel = { };
       let viewPort = viewPortFactory(() => (true));


### PR DESCRIPTION
I removed a test that would erroneously fail. The test was checking that a plan with a childNavigationInstruction property that returned true or false on canDeactivate would continue or cancel respectively. The mock childNavigationInstruction was missing the required childRouter property, and so it was giving erroneous results.

The following test, 'with router and currentInstruction', actually includes coverage for the very same feature. Therefore, removing the erroneous test was sufficient.