### PR TITLE
feat(activation): call can/Deactivate with navigationInstruction

### DIFF
--- a/src/activation.js
+++ b/src/activation.js
@@ -3,7 +3,7 @@ import {isNavigationCommand} from './navigation-commands';
 
 export class CanDeactivatePreviousStep {
   run(navigationInstruction: NavigationInstruction, next: Function) {
-    return processDeactivatable(navigationInstruction.plan, 'canDeactivate', next);
+    return processDeactivatable(navigationInstruction, 'canDeactivate', next);
   }
 }
 
@@ -15,7 +15,7 @@ export class CanActivateNextStep {
 
 export class DeactivatePreviousStep {
   run(navigationInstruction: NavigationInstruction, next: Function) {
-    return processDeactivatable(navigationInstruction.plan, 'deactivate', next, true);
+    return processDeactivatable(navigationInstruction, 'deactivate', next, true);
   }
 }
 
@@ -25,7 +25,8 @@ export class ActivateNextStep {
   }
 }
 
-function processDeactivatable(plan, callbackName, next, ignoreResult) {
+function processDeactivatable(navigationInstruction: NavigationInstruction, callbackName: string, next: Funcion, ignoreResult: boolean) {
+  const plan = navigationInstruction.plan;
   let infos = findDeactivatable(plan, callbackName);
   let i = infos.length; //query from inside out
 
@@ -41,7 +42,7 @@ function processDeactivatable(plan, callbackName, next, ignoreResult) {
     if (i--) {
       try {
         let viewModel = infos[i];
-        let result = viewModel[callbackName]();
+        let result = viewModel[callbackName](navigationInstruction);
         return processPotential(result, inspect, next.cancel);
       } catch (error) {
         return next.cancel(error);

--- a/test/activation.spec.js
+++ b/test/activation.spec.js
@@ -94,6 +94,14 @@ describe('activation', () => {
       expect(state.rejection).toBeTruthy();
     });
 
+    it('should pass a navigationInstruction to the callback function', () => {
+      const instruction = { plan: { first: viewPortFactory(() => (true)) } };
+      const viewModel = instruction.plan.first.prevComponent.viewModel;
+      spyOn(viewModel, 'canDeactivate').and.callThrough();
+      step.run(instruction, state.next);
+      expect(viewModel.canDeactivate).toHaveBeenCalledWith(instruction);      
+    });
+
     describe('with a childNavigationInstruction', () => {
       it('should return true when child is true', () => {
         let viewPort = viewPortFactory(() => (true));


### PR DESCRIPTION
This enables the consumer to inspect the navigation instructions and make a decision on whether or not a route can be deactivated based on the incoming navigation instructions.

Closes #493


