### PR TITLE
feat(router): optional viewports

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "merge2": "^1.0.2",
     "object.assign": "^4.0.4",
-    "require-dir": "^0.3.0",
+    "require-dir": "^0.3.2",
     "run-sequence": "^1.2.2",
     "through2": "^2.0.1",
     "typedoc": "^0.4.4",

--- a/src/route-loading.js
+++ b/src/route-loading.js
@@ -62,7 +62,7 @@ function determineWhatToLoad(navigationInstruction: NavigationInstruction, toLoa
 }
 
 function loadRoute(routeLoader: RouteLoader, navigationInstruction: NavigationInstruction, viewPortPlan: any) {
-  let moduleId = viewPortPlan.config.moduleId;
+  let moduleId = viewPortPlan.config ? viewPortPlan.config.moduleId : null;
 
   return loadComponent(routeLoader, navigationInstruction, viewPortPlan.config).then((component) => {
     let viewPortInstruction = navigationInstruction.addViewPortInstruction(


### PR DESCRIPTION
Makes viewports optional in route configuration. Enables configuring viewports to be either empty or contain previous module.

Depending on aurelia/templating-router/optional-viewports.
Partially closes aurelia/router/issues/482.