### PR TITLE
feat(router): add state parameter to navigation

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -38,9 +38,10 @@ export class AppRouter extends Router {
   * Loads the specified URL.
   *
   * @param url The URL fragment to load.
+  * @param state A state to pass along in the navigation instruction.
   */
-  loadUrl(url): Promise<NavigationInstruction> {
-    return this._createNavigationInstruction(url)
+  loadUrl(url, state?: any): Promise<NavigationInstruction> {
+    return this._createNavigationInstruction(url, null, state)
       .then(instruction => this._queueInstruction(instruction))
       .catch(error => {
         logger.error(error);

--- a/src/router.js
+++ b/src/router.js
@@ -166,8 +166,9 @@ export class Router {
   * @param fragment The URL fragment to use as the navigation destination.
   * @param options The navigation options.
   * @param params The parameters to be used when populating the url pattern.
+  * @param state A state passed in the navigationInstruction.
   */
-  navigate(fragment: string, options?: any, params?: any): boolean {
+  navigate(fragment: string, options?: any, params?: any, state?: any): boolean {
     if (!this.isConfigured && this.parent) {
       return this.parent.navigate(fragment, options);
     }
@@ -178,7 +179,7 @@ export class Router {
     }
 
     this.isExplicitNavigation = true;
-    return this.history.navigate(_resolveUrl(fragment, this.baseUrl, this.history._hasPushState), options);
+    return this.history.navigate(_resolveUrl(fragment, this.baseUrl, this.history._hasPushState), options, state);
   }
 
   /**
@@ -188,9 +189,10 @@ export class Router {
   * @param route The name of the route to use when generating the navigation location.
   * @param params The route parameters to be used when populating the route pattern.
   * @param options The navigation options.
+  * @param state A state passed in the navigationInstruction.
   */
-  navigateToRoute(route: string, params?: any, options?: any): boolean {
-    let path = this.generate(route, params);
+  navigateToRoute(route: string, params?: any, options?: any, state?: any): boolean {
+    let path = this.generate(route, params, {}, state);
     return this.navigate(path, options);
   }
 
@@ -425,7 +427,7 @@ export class Router {
     }
   }
 
-  _createNavigationInstruction(url: string = '', parentInstruction: NavigationInstruction = null): Promise<NavigationInstruction> {
+  _createNavigationInstruction(url: string = '', parentInstruction: NavigationInstruction = null, state?: any): Promise<NavigationInstruction> {
     let fragment = url;
     let queryString = '';
 
@@ -457,7 +459,8 @@ export class Router {
       let instruction = new NavigationInstruction(Object.assign({}, instructionInit, {
         params: Object.assign({}, first.params, parseQueryString(queryString)),
         queryParams: first.queryParams || results.queryParams,
-        config: first.config || first.handler
+        config: first.config || first.handler,
+        state: state
       }));
 
       if (typeof first.handler === 'function') {
@@ -471,7 +474,8 @@ export class Router {
       let instruction = new NavigationInstruction(Object.assign({}, instructionInit, {
         params: Object.assign({ path: fragment }, parseQueryString(queryString)),
         queryParams: results ? results.queryParams : {},
-        config: null // config will be created by the catchAllHandler
+        config: null, // config will be created by the catchAllHandler
+        state: state
       }));
 
       return evaluateNavigationStrategy(instruction, this.catchAllHandler);
@@ -487,7 +491,8 @@ export class Router {
           router: router,
           parentInstruction: newParentInstruction,
           parentCatchHandler: true,
-          config: null // config will be created by the chained parent catchAllHandler
+          config: null, // config will be created by the chained parent catchAllHandler
+          state: state
         }));
 
         return evaluateNavigationStrategy(instruction, router.catchAllHandler);

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,7 @@
 import {RouteRecognizer} from 'aurelia-route-recognizer';
 import {Container} from 'aurelia-dependency-injection';
 import {History} from 'aurelia-history';
+import {buildQueryString, parseQueryString} from 'aurelia-path';
 import {NavigationInstruction} from './navigation-instruction';
 import {NavModel} from './nav-model';
 import {RouterConfiguration} from './router-configuration';
@@ -164,10 +165,16 @@ export class Router {
   *
   * @param fragment The URL fragment to use as the navigation destination.
   * @param options The navigation options.
+  * @param params The parameters to be used when populating the url pattern.
   */
-  navigate(fragment: string, options?: any): boolean {
+  navigate(fragment: string, options?: any, params?: any): boolean {
     if (!this.isConfigured && this.parent) {
       return this.parent.navigate(fragment, options);
+    }
+
+    if (params) {
+      let safeParams = Object.assign({}, params);
+      fragment = this.applyParams(fragment, safeParams);
     }
 
     this.isExplicitNavigation = true;
@@ -205,6 +212,39 @@ export class Router {
     let childRouter = new Router(container || this.container.createChild(), this.history);
     childRouter.parent = this;
     return childRouter;
+  }
+
+  /**
+  * Generates a URL fragment with parameters applied to it.
+  *
+  * @param fragment The route fragment whose pattern should have parameters applied to it.
+  * @param params The route params to be used to populate the route pattern.
+  * @returns {string} A string containing the generated URL fragment.
+  */
+  applyParams(fragment: string, params: any): string {
+    let fragments = fragment.split('/');
+    let consumed = {};
+    for (let i = 0, ilen = fragments.length; i < ilen; ++i) {
+      let segment = fragments[i];
+
+      // Try to parse a parameter :param?
+      let match = segment.match(/^:([^?]+)(\?)?$/);
+      if (match) {
+        let [, name, optional] = match;
+        fragments[i] = params[name];
+        consumed[name] = true;
+      }
+    }
+    fragment = fragments.join('/');
+
+    for (let key of Object.keys(consumed)) {
+      delete params[key];
+    }
+    let query = buildQueryString(params);
+    if (query && query.length) {
+      fragment += (fragment.indexOf('?') < 0 ? '?' : '&') + query;
+    }
+    return fragment;
   }
 
   /**
@@ -415,7 +455,7 @@ export class Router {
     if (results && results.length) {
       let first = results[0];
       let instruction = new NavigationInstruction(Object.assign({}, instructionInit, {
-        params: first.params,
+        params: Object.assign({}, first.params, parseQueryString(queryString)),
         queryParams: first.queryParams || results.queryParams,
         config: first.config || first.handler
       }));
@@ -429,7 +469,7 @@ export class Router {
       return Promise.resolve(instruction);
     } else if (this.catchAllHandler) {
       let instruction = new NavigationInstruction(Object.assign({}, instructionInit, {
-        params: { path: fragment },
+        params: Object.assign({ path: fragment }, parseQueryString(queryString)),
         queryParams: results ? results.queryParams : {},
         config: null // config will be created by the catchAllHandler
       }));
@@ -442,7 +482,7 @@ export class Router {
         let newParentInstruction = this._findParentInstructionFromRouter(router, parentInstruction);
 
         let instruction = new NavigationInstruction(Object.assign({}, instructionInit, {
-          params: { path: fragment },
+          params: Object.assign({ path: fragment }, parseQueryString(queryString)),
           queryParams: results ? results.queryParams : {},
           router: router,
           parentInstruction: newParentInstruction,

--- a/test/app-router.spec.js
+++ b/test/app-router.spec.js
@@ -202,7 +202,7 @@ describe('app-router', () => {
       router.loadUrl('next')
         .then(result => {
           expect(result).toBeFalsy();
-          expect(history.navigate).toHaveBeenCalledWith('#/prev', { trigger: false, replace: true });
+          expect(history.navigate).toHaveBeenCalledWith('#/prev', { trigger: false, replace: true }, undefined);
         })
         .catch(result => expect(true).toBeFalsy('should have succeeded'))
         .then(done);
@@ -216,7 +216,7 @@ describe('app-router', () => {
       router.loadUrl('next')
         .then(result => {
           expect(result).toBeFalsy();
-          expect(history.navigate).toHaveBeenCalledWith('#/fallback', { trigger: true, replace: true });
+          expect(history.navigate).toHaveBeenCalledWith('#/fallback', { trigger: true, replace: true }, undefined);
         })
         .catch(result => expect(true).toBeFalsy('should have succeeded'))
         .then(done);
@@ -236,7 +236,7 @@ describe('app-router', () => {
       router.loadUrl('next')
         .then(result => {
           expect(result).toBeFalsy();
-          expect(history.navigate).toHaveBeenCalledWith('#/prev', { trigger: false, replace: true });
+          expect(history.navigate).toHaveBeenCalledWith('#/prev', { trigger: false, replace: true }, undefined);
         })
         .catch(result => expect(true).toBeFalsy('should have succeeded'))
         .then(done);

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -155,47 +155,47 @@ describe('the router', () => {
         })
       ]).then(() => {
         router.navigate('', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/', options, undefined);
         history.navigate.calls.reset();
 
         router.navigate('#/test1', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/test1', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/test1', options, undefined);
         history.navigate.calls.reset();
 
         router.navigate('/test2', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/test2', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/test2', options, undefined);
         history.navigate.calls.reset();
 
         router.navigate('test3', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/test3', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/test3', options, undefined);
         history.navigate.calls.reset();
 
         child.navigate('#/test4', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/test4', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/test4', options, undefined);
         history.navigate.calls.reset();
 
         child.navigate('/test5', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/test5', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/test5', options, undefined);
         history.navigate.calls.reset();
 
         child.navigate('test6', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/child-router/test6', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/child-router/test6', options, undefined);
         history.navigate.calls.reset();
 
         child.navigate('#/child-router/test7', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/child-router/test7', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/child-router/test7', options, undefined);
         history.navigate.calls.reset();
 
         child.navigate('/child-router/test8', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/child-router/test8', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/child-router/test8', options, undefined);
         history.navigate.calls.reset();
 
         child.navigate('child-router/test9', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/child-router/child-router/test9', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/child-router/child-router/test9', options, undefined);
         history.navigate.calls.reset();
 
         child.navigate('', options);
-        expect(history.navigate).toHaveBeenCalledWith('#/child-router/', options);
+        expect(history.navigate).toHaveBeenCalledWith('#/child-router/', options, undefined);
         history.navigate.calls.reset();
 
         done();
@@ -209,7 +209,7 @@ describe('the router', () => {
       router.configure(config => config.map({ name: 'test', route: 'test/:id', moduleId: './test' }))
         .then(() => {
           router.navigateToRoute('test', { id: 123 }, options);
-          expect(history.navigate).toHaveBeenCalledWith('#/test/123', options);
+          expect(history.navigate).toHaveBeenCalledWith('#/test/123', options, undefined);
           done();
         });
     });


### PR DESCRIPTION
Adds a `state` parameter to the `navigate` and `navigateToRoute` functions. The parameter is transfered to a `state` property on the NavigationInstruction.

Depends on aurelia/history-browser#30.
Closes aurelia/router#479.