### PR TITLE
feat(router): Support optional and default view ports

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "merge2": "^1.0.2",
     "object.assign": "^4.0.4",
-    "require-dir": "^0.3.0",
+    "require-dir": "^0.3.2",
     "run-sequence": "^1.2.2",
     "through2": "^2.0.1",
     "typedoc": "^0.4.4",

--- a/src/route-loading.js
+++ b/src/route-loading.js
@@ -62,7 +62,7 @@ function determineWhatToLoad(navigationInstruction: NavigationInstruction, toLoa
 }
 
 function loadRoute(routeLoader: RouteLoader, navigationInstruction: NavigationInstruction, viewPortPlan: any) {
-  let moduleId = viewPortPlan.config.moduleId;
+  let moduleId = viewPortPlan.config ? viewPortPlan.config.moduleId : null;
 
   return loadComponent(routeLoader, navigationInstruction, viewPortPlan.config).then((component) => {
     let viewPortInstruction = navigationInstruction.addViewPortInstruction(

--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -92,6 +92,18 @@ export class RouterConfiguration {
   }
 
   /**
+   * Configures defaults to use for any view ports.
+   *
+   * @param viewPortConfig a view port configuration object to use as a 
+   *  default, of the form { viewPortName: { moduleId } }.
+   * @chainable
+   */
+  useViewPortDefaults(viewPortConfig: any) {
+    this.viewPortDefaults = viewPortConfig;
+    return this;
+  }
+
+  /**
   * Maps a single route to be registered with the router.
   *
   * @param route The [[RouteConfig]] to map.
@@ -161,6 +173,10 @@ export class RouterConfiguration {
       router.fallbackRoute = this._fallbackRoute;
     }
 
+    if (this.viewPortDefaults) {
+      router.useViewPortDefaults(this.viewPortDefaults);
+    }
+
     router.options = this.options;
 
     let pipelineSteps = this.pipelineSteps;
@@ -174,10 +190,6 @@ export class RouterConfiguration {
         let {name, step} = pipelineSteps[i];
         pipelineProvider.addStep(name, step);
       }
-    }
-
-    if (this.viewPortDefaults) {
-      router.viewPortDefaults = this.viewPortDefaults;
     }
   }
 }

--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -11,6 +11,7 @@ export class RouterConfiguration {
   pipelineSteps: Array<Function|PipelineStep> = [];
   title: string;
   unknownRouteConfig: any;
+  viewPortDefaults: any;
 
   /**
   * Adds a step to be run during the [[Router]]'s navigation pipeline.
@@ -173,6 +174,10 @@ export class RouterConfiguration {
         let {name, step} = pipelineSteps[i];
         pipelineProvider.addStep(name, step);
       }
+    }
+
+    if (this.viewPortDefaults) {
+      router.viewPortDefaults = this.viewPortDefaults;
     }
   }
 }

--- a/src/router.js
+++ b/src/router.js
@@ -65,6 +65,11 @@ export class Router {
   options: any = {};
 
   /**
+  * The defaults used when a viewport lacks specified content
+  */
+  viewPortDefaults: any;
+
+  /**
   * Extension point to transform the document title before it is built and displayed.
   * By default, child routers delegate to the parent router, and the app router
   * returns the title unchanged.

--- a/src/router.js
+++ b/src/router.js
@@ -67,7 +67,7 @@ export class Router {
   /**
   * The defaults used when a viewport lacks specified content
   */
-  viewPortDefaults: any;
+  viewPortDefaults: any = {};
 
   /**
   * Extension point to transform the document title before it is built and displayed.
@@ -105,6 +105,7 @@ export class Router {
     this.isExplicitNavigationBack = false;
     this.navigation = [];
     this.currentInstruction = null;
+    this.viewPortDefaults = {};
     this._fallbackOrder = 100;
     this._recognizer = new RouteRecognizer();
     this._childRecognizer = new RouteRecognizer();
@@ -380,6 +381,20 @@ export class Router {
         current.href = _createRootedPath(current.relativeHref, this.baseUrl, this.history._hasPushState);
       } else {
         current.href = _normalizeAbsolutePath(current.config.href, this.history._hasPushState);
+      }
+    }
+  }
+
+  /** 
+   * Sets the default configuration for the view ports. This specifies how to
+   *  populate a view port for which no module is specified. The default is 
+   *  an empty view/view-model pair.
+   */
+  useViewPortDefaults(viewPortDefaults: any) {
+    for (let viewPortName in viewPortDefaults) {
+      let viewPortConfig = viewPortDefaults[viewPortName];
+      this.viewPortDefaults[viewPortName] = {
+        moduleId: viewPortConfig.moduleId
       }
     }
   }


### PR DESCRIPTION
Before, all viewports had to be specified in every route. This feature enables omitting a viewport or specifying a default viewport.

Any viewport configuration with `moduleId: null` will use the default viewport configuration. Initially, the default viewport configuration is an empty view and view model pair. You can override this by passing a viewport configuration to the `useDefaultViewPort()` method on `RouterConfiguration`.

```javascript
configureRouter(config, router) {
  // this means that whenever the menu viewport is populated with { moduleId: null } in the router, it will populate with the 'defaultMenu' module.
  config.useDefaultViewPort({ menu: { moduleId: PLATFORM.module('defaultMenu') } });
}
```

If a route is missing a viewport configuration, then that route will remain unchanged. If there is no history, then that route will use the default viewport configuration. This allows you to specify routes that operate only on one viewport at a time.