### PR TITLE
fix(navigation-instruction): Wait to swap child routes

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -214,17 +214,15 @@ export class NavigationInstruction {
 
       if (viewPortInstruction.strategy === activationStrategy.replace) {
         if (viewPortInstruction.childNavigationInstruction && viewPortInstruction.childNavigationInstruction.parentCatchHandler) {
-          loads.push(viewPortInstruction.childNavigationInstruction._commitChanges());
+          loads.push(viewPortInstruction.childNavigationInstruction._commitChanges(waitToSwap));
         } else {
           if (waitToSwap) {
             delaySwaps.push({viewPort, viewPortInstruction});
           }
           loads.push(viewPort.process(viewPortInstruction, waitToSwap).then((x) => {
             if (viewPortInstruction.childNavigationInstruction) {
-              return viewPortInstruction.childNavigationInstruction._commitChanges();
+              return viewPortInstruction.childNavigationInstruction._commitChanges(waitToSwap);
             }
-
-            return undefined;
           }));
         }
       } else {


### PR DESCRIPTION
The waitToSwap variable was not properly being passed to child routes' _commitChanges(), which introduced a timing issue where a child router's baseUrl was not updated before it was bound. This commit adds the variable back in.

Resolves https://github.com/aurelia/router/issues/306
Resolves https://github.com/aurelia/router/issues/552
Resolves https://github.com/aurelia/templating-router/issues/46