### PR TITLE
fix(router): define title property

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -27,6 +27,11 @@ export class Router {
   */
   baseUrl: string;
 
+  /**   
+   * If defined, used in generation of document title for [[Router]]'s routes.
+   */
+  title: string | undefined
+
   /**
   * True if the [[Router]] has been configured.
   */


### PR DESCRIPTION
Attempt to resolve #573 .
Added a property in router. It is used in NavigationInstruction and RouterConfiguration