### PR TITLE
feat(router): add configurable title separator

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -258,7 +258,7 @@ export class NavigationInstruction {
       let viewPortInstruction = this.viewPortInstructions[viewPortName];
 
       if (viewPortInstruction.childNavigationInstruction) {
-        let childTitle = viewPortInstruction.childNavigationInstruction._buildTitle(separator);
+        let childTitle = viewPortInstruction.childNavigationInstruction._buildTitle(titleSeparator);
         if (childTitle) {
           childTitles.push(childTitle);
         }
@@ -266,11 +266,11 @@ export class NavigationInstruction {
     }
 
     if (childTitles.length) {
-      title = childTitles.join(separator) + (title ? separator : '') + title;
+      title = childTitles.join(titleSeparator) + (title ? titleSeparator : '') + title;
     }
 
     if (this.router.title) {
-      title += (title ? separator : '') + this.router.transformTitle(this.router.title);
+      title += (title ? titleSeparator : '') + this.router.transformTitle(this.router.title);
     }
 
     return title;

--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -245,7 +245,7 @@ export class NavigationInstruction {
     }
   }
 
-  _buildTitle(separator: string = ' | '): string {
+  _buildTitle(): string {
     let title = '';
     let childTitles = [];
 
@@ -257,7 +257,7 @@ export class NavigationInstruction {
       let viewPortInstruction = this.viewPortInstructions[viewPortName];
 
       if (viewPortInstruction.childNavigationInstruction) {
-        let childTitle = viewPortInstruction.childNavigationInstruction._buildTitle(separator);
+        let childTitle = viewPortInstruction.childNavigationInstruction._buildTitle();
         if (childTitle) {
           childTitles.push(childTitle);
         }
@@ -265,11 +265,11 @@ export class NavigationInstruction {
     }
 
     if (childTitles.length) {
-      title = childTitles.join(separator) + (title ? separator : '') + title;
+      title = childTitles.join(this.router.separator) + (title ? this.router.separator : '') + title;
     }
 
     if (this.router.title) {
-      title += (title ? separator : '') + this.router.transformTitle(this.router.title);
+      title += (title ? this.router.separator : '') + this.router.transformTitle(this.router.title);
     }
 
     return title;

--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -245,9 +245,10 @@ export class NavigationInstruction {
     }
   }
 
-  _buildTitle(): string {
+  _buildTitle(separator?: string): string {
     let title = '';
     let childTitles = [];
+    let titleSeparator = separator || this.router.titleSeparator;
 
     if (this.config.navModel.title) {
       title = this.router.transformTitle(this.config.navModel.title);
@@ -257,7 +258,7 @@ export class NavigationInstruction {
       let viewPortInstruction = this.viewPortInstructions[viewPortName];
 
       if (viewPortInstruction.childNavigationInstruction) {
-        let childTitle = viewPortInstruction.childNavigationInstruction._buildTitle();
+        let childTitle = viewPortInstruction.childNavigationInstruction._buildTitle(separator);
         if (childTitle) {
           childTitles.push(childTitle);
         }
@@ -265,11 +266,11 @@ export class NavigationInstruction {
     }
 
     if (childTitles.length) {
-      title = childTitles.join(this.router.separator) + (title ? this.router.separator : '') + title;
+      title = childTitles.join(separator) + (title ? separator : '') + title;
     }
 
     if (this.router.title) {
-      title += (title ? this.router.separator : '') + this.router.transformTitle(this.router.title);
+      title += (title ? separator : '') + this.router.transformTitle(this.router.title);
     }
 
     return title;

--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -18,6 +18,7 @@ export class RouterConfiguration {
   } = {};
   pipelineSteps: Array<{name: string, step: Function|PipelineStep}> = [];
   title: string;
+  titleSeparator: string;
   unknownRouteConfig: string|RouteConfig|((instruction: NavigationInstruction) => string|RouteConfig|Promise<string|RouteConfig>);
   viewPortDefaults: {[name: string]: {moduleId: string|void; [key: string]: any}};
 
@@ -161,6 +162,7 @@ export class RouterConfiguration {
 
     if (this.title) {
       router.title = this.title;
+      router.titleSeparator = this.titleSeparator || ' | ';
     }
 
     if (this.unknownRouteConfig) {

--- a/src/router.js
+++ b/src/router.js
@@ -32,7 +32,12 @@ export class Router {
   /**
    * If defined, used in generation of document title for [[Router]]'s routes.
    */
-  title: string | undefined
+  title: string | undefined;
+
+  /**
+   * The separator used in the document title between [[Router]]'s routes.
+   */
+  titleSeparator: string;
 
   /**
   * True if the [[Router]] has been configured.


### PR DESCRIPTION
Partly solves https://github.com/aurelia/router/issues/419.
Title can now be set for each router by setting a property in the `configureRouter` function: `config.titleSeparator = ' - ';`.

This PR should solve most use cases, in the future we could for example look at making the separator configurable for each route by adding it to the NavModel.