### PR TITLE
fix(app-router): await navigation result

### DIFF
--- a/src/app-router.js
+++ b/src/app-router.js
@@ -197,8 +197,9 @@ function processResult(instruction, result, instructionCount, router) {
   }
 
   let finalResult = null;
+  let navigationCommandResult = null;
   if (isNavigationCommand(result.output)) {
-    result.output.navigate(router);
+    navigationCommandResult = result.output.navigate(router);
   } else {
     finalResult = result;
 
@@ -211,7 +212,8 @@ function processResult(instruction, result, instructionCount, router) {
     }
   }
 
-  return router._dequeueInstruction(instructionCount + 1)
+  return Promise.resolve(navigationCommandResult)
+    .then(_ => router._dequeueInstruction(instructionCount + 1))
     .then(innerResult => finalResult || innerResult || result);
 }
 


### PR DESCRIPTION
Navigation command (eg. redirect) in child route navigation strategy was not working, when parent route was also using a navigation strategy

Fixes https://github.com/aurelia/router/issues/588