### PR TITLE
doc(router-configuration): add webpack configuration

### DIFF
--- a/doc/article/en-US/router-configuration.md
+++ b/doc/article/en-US/router-configuration.md
@@ -1141,3 +1141,42 @@ Since the view model's navigation lifecycle is called only once, you may have pr
 
 > Info
 > Alternatively, if the strategy is always the same and you don't want that to be in your view model code, you can add the `activationStrategy` property to your route config instead.
+
+## Webpack Configuration
+
+When using webpack it is necessary to help Aurelia create a path that is resolvable by the loader, this is done by wrapping the contents of `moduleId` with `PLATFORM.moduleName()`. You can import `PLATFORM` into your project from either `aurelia-framework` or `aurelia-pal`.
+
+The method `moduleName` takes up to two parameters: 
+
+`moduleName(moduleName: string, options?: ModuleNameOptions): string`
+
+The first argument is the name of the view-model that you want to use and the second (optional) argument generates a bundle based on the supplied value.
+
+See below for a simple example on how to use `PLATFORM.moduleName` in your router configuration:
+
+<code-listing heading="app${context.language.fileExtension}">
+  <source-code lang="ES 2015/2016">
+    import { PLATFORM } from "aurelia-framework";
+
+    export class App {
+      configureRouter(config, router) {
+        config.map([
+          { route: ['', 'home'],   name: 'home',    moduleId: PLATFORM.moduleName('home') }
+        ]);
+
+        this.router = router;
+      }
+    }
+  </source-code>
+  <source-code lang="TypeScript">
+    import { PLATFORM } from "aurelia-framework";
+
+    export class App {
+      configureRouter(config: RouterConfiguration, router: Router): void {
+        config.map([
+          { route: ['', 'home'],   name: 'home',    moduleId: PLATFORM.moduleName('home') }
+        ]);
+      }
+    }
+  </source-code>
+</code-listing>


### PR DESCRIPTION
There is currently no place in the router-configuration documentation that describes how to resolve moduleId when using webpack.

Closes https://github.com/aurelia/framework/issues/883