### PR TITLE
fix(router-configuration): throw early on invalid pipeline steps

### DIFF
--- a/src/router-configuration.js
+++ b/src/router-configuration.js
@@ -30,6 +30,9 @@ export class RouterConfiguration {
   * @chainable
   */
   addPipelineStep(name: string, step: Function|PipelineStep): RouterConfiguration {
+    if (step === null || step === undefined) {
+      throw new Error('Pipeline step cannot be null or undefined.');
+    }
     this.pipelineSteps.push({name, step});
     return this;
   }


### PR DESCRIPTION
An error with Router.addPipelineStep leads to the usual 'key/value cannot be null or undefined. Are you trying to inject/register something that doesn\'t exist with DI?' at a later stage, making debugging difficult. 

I suggest to add the test to addPipelineStep which lets the error appear where it was created.