### PR TITLE
Fix: Router ignored the root when creating hrefs

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -224,7 +224,7 @@ export class Router {
     }
 
     this.isExplicitNavigation = true;
-    return this.history.navigate(_resolveUrl(fragment, this.baseUrl, this.history._hasPushState), options);
+    return this.history.navigate(_resolveUrl(fragment, this.baseUrl, this.history._hasPushState, this.history.root), options);
   }
 
   /**
@@ -279,8 +279,21 @@ export class Router {
     }
 
     let path = this._recognizer.generate(name, params);
-    let rootedPath = _createRootedPath(path, this.baseUrl, this.history._hasPushState, options.absolute);
-    return options.absolute ? `${this.history.getAbsoluteRoot()}${rootedPath}` : rootedPath;
+    let rootedPath = _createRootedPath(path, this.baseUrl, this.history._hasPushState, this.history.root);
+    if (options.absolute) {
+      // Hamfisted workaround because history does not expose the origin without the root
+      let origin = this.history.getAbsoluteRoot();
+      if (this.history._hasPushState) {
+        if (this.history.root) {
+          origin = origin.substring(0, origin.length - this.history.root.length);
+        } else {
+          origin = origin.substring(0, origin.length - 1);
+        }
+      }
+
+      rootedPath = origin + rootedPath;
+    }
+    return rootedPath;
   }
 
   /**
@@ -431,9 +444,9 @@ export class Router {
     for (let i = 0, length = nav.length; i < length; i++) {
       let current = nav[i];
       if (!current.config.href) {
-        current.href = _createRootedPath(current.relativeHref, this.baseUrl, this.history._hasPushState);
+        current.href = _createRootedPath(current.relativeHref, this.baseUrl, this.history._hasPushState, this.history.root);
       } else {
-        current.href = _normalizeAbsolutePath(current.config.href, this.history._hasPushState);
+        current.href = _normalizeAbsolutePath(current.config.href, this.history._hasPushState, this.history.root);
       }
     }
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,16 +1,16 @@
-export function _normalizeAbsolutePath(path, hasPushState, absolute = false) {
+export function _normalizeAbsolutePath(path, hasPushState, root) {
   if (!hasPushState && path[0] !== '#') {
     path = '#' + path;
   }
 
-  if (hasPushState && absolute) {
-    path = path.substring(1, path.length);
+  if (hasPushState && root) {
+    path = root + path.substring(1, path.length);
   }
 
   return path;
 }
 
-export function _createRootedPath(fragment, baseUrl, hasPushState, absolute) {
+export function _createRootedPath(fragment, baseUrl, hasPushState, root) {
   if (isAbsoluteUrl.test(fragment)) {
     return fragment;
   }
@@ -31,15 +31,15 @@ export function _createRootedPath(fragment, baseUrl, hasPushState, absolute) {
     path = path.substring(0, path.length - 1);
   }
 
-  return _normalizeAbsolutePath(path + fragment, hasPushState, absolute);
+  return _normalizeAbsolutePath(path + fragment, hasPushState, root);
 }
 
-export function _resolveUrl(fragment, baseUrl, hasPushState) {
+export function _resolveUrl(fragment, baseUrl, hasPushState, root) {
   if (isRootedPath.test(fragment)) {
-    return _normalizeAbsolutePath(fragment, hasPushState);
+    return _normalizeAbsolutePath(fragment, hasPushState, root);
   }
 
-  return _createRootedPath(fragment, baseUrl, hasPushState);
+  return _createRootedPath(fragment, baseUrl, hasPushState, root);
 }
 
 export function _ensureArrayWithSingleRoutePerConfig(config) {


### PR DESCRIPTION
Aurelia router generated absolute paths but did not append the root path (ie. `<base href="…">`). This is incorrect and caused all non-default click actions (eg. CMD+Click, Right-click-> "Open in new Tab/Browser", etc.) to navigate to the wrong URL. (And broke links for crawlers.)

Normal clicks only worked because they are intercepted by Aurelia and forwarded to `aurelia-browser-history`, which contains [a corresponding bug](https://github.com/aurelia/history-browser/pull/41) that treats all URLs as fragments instead of expecting the base path to be present in absolute paths.

This fix requires [the corresponding fix for `aurelia-browser-history`](https://github.com/aurelia/history-browser/pull/41) or the history will forward incorrect fragments to the router.