### PR TITLE
Feature: cross-module devmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,28 @@ To build the code, follow these steps.
   ```shell
   gulp build
   ```
-5. You will find the compiled code in the `dist` folder, available in three module formats: AMD, CommonJS and ES6.
+5. You will find the compiled code in the `dist` folder, available in various module formats: AMD, CommonJS, ES6 …
+
+  Use `gulp build --format <format1> [--format <format2> …]` to build only certain formats.
 
 6. See `gulpfile.js` for other tasks related to generating the docs and linting.
+
+### Continuious building and cross-module development
+
+  To build the dist files whenever you make any changes, run:
+
+  ```shell
+  gulp dev
+  ```
+
+  If you want to test your changes in the context of another module that depends on `aurelia-router`, run
+
+  ```shell
+  gulp dev --target <target_module_dir> [--format <format>]
+  ```
+
+  Whenever changes are compiled, they’ll automatically be copied to the `aurelia-router` module within the target module, e.g., `<target_module_dir>/node_modules/aurelia-router` or the jspm equivalent.
+
 
 ## Running The Tests
 

--- a/build/tasks/args.js
+++ b/build/tasks/args.js
@@ -1,0 +1,11 @@
+module.exports = require('yargs')
+  .options('target', {
+    alias: 't',
+    description: 'target module dir to copy build results into (eg. "--target ../other-module" to copy build results into "../other-module/node_modules/this-module/dist/…" whenever they change)'
+  })
+  .options('format', {
+    alias: 'f',
+    array: true,
+    description: 'format to compile to (eg. "es2015", "commonjs", …). Can be set muliple times to compile to multiple formats. Default is all formats.'
+  })
+  .argv;

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -1,21 +1,23 @@
-var gulp = require('gulp');
-var runSequence = require('run-sequence');
-var to5 = require('gulp-babel');
-var paths = require('../paths');
-var compilerOptions = require('../babel-options');
-var compilerTsOptions = require('../typescript-options');
-var assign = Object.assign || require('object.assign');
-var through2 = require('through2');
-var concat = require('gulp-concat');
-var insert = require('gulp-insert');
-var rename = require('gulp-rename');
-var tools = require('aurelia-tools');
-var ts = require('gulp-typescript');
-var gutil = require('gulp-util');
-var gulpIgnore = require('gulp-ignore');
-var merge = require('merge2');
-var jsName = paths.packageName + '.js';
-var compileToModules = ['es2015', 'commonjs', 'amd', 'system', 'native-modules'];
+const gulp = require('gulp');
+const runSequence = require('run-sequence');
+const to5 = require('gulp-babel');
+const paths = require('../paths');
+const compilerOptions = require('../babel-options');
+const compilerTsOptions = require('../typescript-options');
+const assign = Object.assign || require('object.assign');
+const through2 = require('through2');
+const concat = require('gulp-concat');
+const insert = require('gulp-insert');
+const rename = require('gulp-rename');
+const tools = require('aurelia-tools');
+const ts = require('gulp-typescript');
+const gutil = require('gulp-util');
+const gulpIgnore = require('gulp-ignore');
+const merge = require('merge2');
+const args = require('./args');
+
+const jsName = paths.packageName + '.js';
+const compileToModules = args.format || ['es2015', 'commonjs', 'amd', 'system', 'native-modules'];
 
 function cleanGeneratedCode() {
   return through2.obj(function(file, enc, callback) {

--- a/build/tasks/dev.js
+++ b/build/tasks/dev.js
@@ -1,5 +1,16 @@
-var gulp = require('gulp');
-var tools = require('aurelia-tools');
+const fs = require('fs');
+const path = require('path');
+
+const gulp = require('gulp');
+const tools = require('aurelia-tools');
+const glob = require("glob")
+const paths = require('../paths');
+const args = require('yargs')
+    .options('target', {
+        alias: 't',
+        description: 'target module dir to copy build results into (eg. "--target ../other-module" to copy build results into "../other-module/node_modules/this-module/dist/…" whenever they change)',
+    })
+    .argv;
 
 gulp.task('update-own-deps', function(){
   tools.updateOwnDependenciesFromLocalRepositories();
@@ -7,4 +18,41 @@ gulp.task('update-own-deps', function(){
 
 gulp.task('build-dev-env', function () {
   tools.buildDevEnv();
+});
+
+gulp.task('dev', ['build'], () => {
+  gulp.watch(paths.files, ['build']);
+
+  if (args.target) {
+    const projectName = require('../../package.json').name;
+
+    const targetNPMPath = path.join(args.target, 'node_modules', projectName);
+    fs.stat(targetNPMPath, (err, stats) => {
+      if (!err && stats.isDirectory()) {
+        const targetNPMDistPath = path.join(targetNPMPath, paths.output);
+        watchAndCopy(paths.output, targetNPMDistPath);
+      }
+    });
+
+    const targetJSPMGlob = path.join(args.target, 'jspm_packages', 'npm', projectName + '@*/');
+    glob(targetJSPMGlob, (err, files) => {
+      if (!err && files.length === 1) {
+        const targetJSPMPath = files[0];
+        const amdPath = path.join(paths.output, 'amd');
+        watchAndCopy(amdPath, targetJSPMPath);
+      }
+    });
+
+    function watchAndCopy(basePath, targetPath) {
+        gulp.watch(path.join(basePath, '**', '*'), (event) => {
+          if (event.type === 'deleted') {
+            return;
+          }
+
+          const relativePath = path.relative(basePath, event.path);
+          const destPath = path.join(targetPath, relativePath);
+          fs.createReadStream(event.path).pipe(fs.createWriteStream(destPath));
+        });
+    }
+  }
 });

--- a/build/tasks/dev.js
+++ b/build/tasks/dev.js
@@ -3,14 +3,14 @@ const path = require('path');
 
 const gulp = require('gulp');
 const tools = require('aurelia-tools');
-const glob = require("glob")
+const glob = require('glob');
 const paths = require('../paths');
 const args = require('yargs')
-    .options('target', {
-        alias: 't',
-        description: 'target module dir to copy build results into (eg. "--target ../other-module" to copy build results into "../other-module/node_modules/this-module/dist/…" whenever they change)',
-    })
-    .argv;
+  .options('target', {
+    alias: 't',
+    description: 'target module dir to copy build results into (eg. "--target ../other-module" to copy build results into "../other-module/node_modules/this-module/dist/…" whenever they change)'
+  })
+  .argv;
 
 gulp.task('update-own-deps', function(){
   tools.updateOwnDependenciesFromLocalRepositories();
@@ -42,17 +42,17 @@ gulp.task('dev', ['build'], () => {
         watchAndCopy(amdPath, targetJSPMPath);
       }
     });
-
-    function watchAndCopy(basePath, targetPath) {
-        gulp.watch(path.join(basePath, '**', '*'), (event) => {
-          if (event.type === 'deleted') {
-            return;
-          }
-
-          const relativePath = path.relative(basePath, event.path);
-          const destPath = path.join(targetPath, relativePath);
-          fs.createReadStream(event.path).pipe(fs.createWriteStream(destPath));
-        });
-    }
   }
 });
+
+function watchAndCopy(basePath, targetPath) {
+  gulp.watch(path.join(basePath, '**', '*'), (event) => {
+    if (event.type === 'deleted') {
+      return;
+    }
+
+    const relativePath = path.relative(basePath, event.path);
+    const destPath = path.join(targetPath, relativePath);
+    fs.createReadStream(event.path).pipe(fs.createWriteStream(destPath));
+  });
+}

--- a/build/tasks/dev.js
+++ b/build/tasks/dev.js
@@ -5,12 +5,7 @@ const gulp = require('gulp');
 const tools = require('aurelia-tools');
 const glob = require('glob');
 const paths = require('../paths');
-const args = require('yargs')
-  .options('target', {
-    alias: 't',
-    description: 'target module dir to copy build results into (eg. "--target ../other-module" to copy build results into "../other-module/node_modules/this-module/dist/…" whenever they change)'
-  })
-  .argv;
+const args = require('./args');
 
 gulp.task('update-own-deps', function(){
   tools.updateOwnDependenciesFromLocalRepositories();

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "babel-preset-es2015-loose-native-modules": "^1.0.0",
     "babel-preset-stage-1": "^6.5.0",
     "del": "^2.2.1",
+    "glob": "^7.1.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-bump": "^2.2.0",


### PR DESCRIPTION
This PR adds a task `gulp dev [--target <module>]`. This supports cross-module development by allowing you to test changes of one module in the context of another module.

This solves [the problems discussed here](https://discourse.aurelia.io/t/how-do-you-setup-your-development-environment-for-core-modules/1271?u=rluba).

An example: Run `gulp dev --target ../my-project` to work on `aurelia-router` and test all changes in the context of `my-project` that’s installed in a sibling directory. Whenever you make any changes to any files in `aurelia-router`…
1. it is automatically recompiled and
2. the result is copied into the `aurelia-router` module within `my-project`.

If you use webpack in watch-mode on `my-project` (eg. in a second shell tab), you can immediately test any changes:

1. Make changes to `aurelia-router`
2. Hit save
3. Reload you browser
4. Test your changes and repeat

The current state of this PR is intended as a starting point for discussions and by no means a complete solution. In my opinion it’s already way better than the status quo, but it lacks a lot of robustness checks:

- find `node_modules` though npm configuration instead of expecting it at `<root>/node_modules`,
- same for jspm
- handle fs stream errors
- handle fs.stat errors properly
- handle glob errors properly

What do you think? If you like this solution, we can roll it out on all aurelia projects.