### PR TITLE
Fix error introduced in 487c33d5 (when trying to fix #480)

### DIFF
--- a/src/navigation-plan.js
+++ b/src/navigation-plan.js
@@ -85,6 +85,9 @@ export function _buildNavigationPlan(instruction: NavigationInstruction, forceLi
               childInstruction,
               viewPortPlan.strategy === activationStrategy.invokeLifecycle)
               .then(childPlan => {
+                if (childPlan instanceof Redirect) {
+                  return Promise.reject(childPlan);
+                }
                 childInstruction.plan = childPlan;
               });
           });

--- a/src/route-loading.js
+++ b/src/route-loading.js
@@ -81,6 +81,9 @@ function loadRoute(routeLoader: RouteLoader, navigationInstruction: NavigationIn
 
           return _buildNavigationPlan(childInstruction)
             .then((childPlan) => {
+              if (childPlan instanceof Redirect) {
+                return Promise.reject(childPlan);
+              }
               childInstruction.plan = childPlan;
               viewPortInstruction.childNavigationInstruction = childInstruction;
 


### PR DESCRIPTION
This causes #480 to re-appear until a better handling for cancellations exists – but it’s still better than the errors caused by improper handling of redirects at the moment.

There’s no easy way to call `next.cancel` from all places that can create a redirect. I’d suggest changing redirects to add a magic value to an `Error` (eg. `error.redirect = new Redirect(…)`) and rejecting with that.

But this would require changes in several places that check for `output instanceof Error` to determine the kind of result.