### PR TITLE
Fix/child redirect

### DIFF
--- a/src/navigation-instruction.js
+++ b/src/navigation-instruction.js
@@ -198,7 +198,6 @@ export class NavigationInstruction {
 
     this.config.navModel.isActive = true;
 
-    router._refreshBaseUrl();
     router.refreshNavigation();
 
     let loads = [];

--- a/test/navigation-instruction.spec.js
+++ b/test/navigation-instruction.spec.js
@@ -88,7 +88,7 @@ describe('NavigationInstruction', () => {
           done();
         });
       });
-    });  
+    });
   });
 
   describe('getBaseUrl()', () => {
@@ -182,9 +182,7 @@ describe('NavigationInstruction', () => {
       it('should return the non-empty matching parent route', (done) => {
         router._createNavigationInstruction('').then(parentInstruction => {
           router.currentInstruction = parentInstruction;
-          router._refreshBaseUrl();
-          child._createNavigationInstruction(childRouteName).then(instruction => {
-            child._refreshBaseUrl();
+          child._createNavigationInstruction(childRouteName, parentInstruction).then(instruction => {
             expect(child.baseUrl).toBe(parentRouteName);
             done();
           });
@@ -197,15 +195,24 @@ describe('NavigationInstruction', () => {
       it('should return the non-empty matching parent route', (done) => {
         router._createNavigationInstruction(parentRouteName).then(parentInstruction => {
           router.currentInstruction = parentInstruction;
-          router._refreshBaseUrl();
-          child._createNavigationInstruction(childRouteName).then(instruction => {
-            child._refreshBaseUrl();
+          child._createNavigationInstruction(childRouteName, parentInstruction).then(instruction => {
             expect(child.baseUrl).toBe(parentRouteName);
             done();
           });
         })
         .catch(fail);
       });
+    });
+
+    it('should update the base url when generating navigation instructions', (done) => {
+      router._createNavigationInstruction(parentRouteName).then(parentInstruction => {
+        router.currentInstruction = parentInstruction;
+        child._createNavigationInstruction(childRouteName, parentInstruction).then(instruction => {
+          expect(child.baseUrl).toBe(parentRouteName);
+          done();
+        });
+      })
+      .catch(fail);
     });
   });
 });

--- a/test/navigation-plan.spec.js
+++ b/test/navigation-plan.spec.js
@@ -16,12 +16,14 @@ describe('NavigationPlanStep', () => {
   let sameAsFirstInstruction;
   let secondInstruction;
   let router;
+  let child;
 
   beforeEach(() => {
     step = new BuildNavigationPlanStep();
     state = createPipelineState();
     router = new AppRouter(new Container(), new MockHistory(), new PipelineProvider(new Container()));
     router.useViewPortDefaults({ default: { moduleId: null } });
+    child = router.createChild(new Container());
 
     redirectInstruction = new NavigationInstruction({
       fragment: 'first',
@@ -83,6 +85,28 @@ describe('NavigationPlanStep', () => {
         expect(e.url).toBe('#/second/10?q=1');
         done();
       });
+  });
+
+  it('redirects children', (done) => {
+    const url = 'home/first';
+    const base = { name: 'home', route: 'home', moduleId: './home' };
+    const from = { name: 'first', route: 'first', redirect: 'second' };
+    const to = { name: 'second', route: 'second', moduleId: './second' };
+
+    router.addRoute(base);
+    child.configure(config => config.map([from, to]));
+    router.navigate('home');
+    router._createNavigationInstruction(url).then((parentInstruction) => {
+      child._createNavigationInstruction(parentInstruction.getWildcardPath(), parentInstruction).then(childInstruction => {
+        step.run(childInstruction, state.next)
+          .then(e => {
+            expect(state.rejection).toBeTruthy();
+            expect(e instanceof Redirect).toBe(true);
+            expect(e.url).toBe(`#/home/second`);
+            done();
+          });
+      });
+    });
   });
 
   describe('generates navigation plans', () => {


### PR DESCRIPTION
router.baseUrl is used to generate urls for a route configured on any given router. The baseUrl is set by a router's current parent instruction. In light of this, it was originally designed to update the baseUrl when the parent instruction was fully processed and accepted, on the commitChanges step. However, this has always been a problem for child routers using redirect. They cannot use the generate method to generate a new URL because the baseUrl hasn't yet been updated.

This test demands a totally different approach. Whenever the router creates a new instruction the baseUrl should be updated. This is a well defined solution if we never enter a state where a baseUrl was updated to a value that was never finalized. This is never the case since a child router is--as far as I know--tied to the parent route. If the parent route fails to activate, then the child router is discarded. It will have an invalid value on it, but it will never be used for any purpose.

I don't anticipate any breaking changes. This should answer some issues of unexpected behavior with the router, including #378. If someone was relying on this behavior it may cause issues, but it was never a promised or documented behavior.