### PR TITLE
fix(typings): Revert aliasing interface

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -212,8 +212,3 @@ interface PipelineResult {
   output: any;
   completed: boolean;
 }
-
-/**
-* The result of a router navigation.
-*/
-export type NavigationResult = Promise<PipelineResult | boolean>;

--- a/src/router.js
+++ b/src/router.js
@@ -10,7 +10,7 @@ import {
   _createRootedPath,
   _resolveUrl
 } from './util';
-import {RouteConfig, NavigationResult} from './interfaces';
+import {RouteConfig} from './interfaces';
 
 /**
 * The primary class responsible for handling routing and navigation.
@@ -218,7 +218,7 @@ export class Router {
   * @param fragment The URL fragment to use as the navigation destination.
   * @param options The navigation options.
   */
-  navigate(fragment: string, options?: NavigationOptions): NavigationResult {
+  navigate(fragment: string, options?: NavigationOptions): Promise<PipelineResult | boolean> {
     if (!this.isConfigured && this.parent) {
       return this.parent.navigate(fragment, options);
     }
@@ -235,7 +235,7 @@ export class Router {
   * @param params The route parameters to be used when populating the route pattern.
   * @param options The navigation options.
   */
-  navigateToRoute(route: string, params?: any, options?: NavigationOptions): NavigationResult {
+  navigateToRoute(route: string, params?: any, options?: NavigationOptions): Promise<PipelineResult | boolean> {
     let path = this.generate(route, params);
     return this.navigate(path, options);
   }

--- a/src/router.js
+++ b/src/router.js
@@ -10,7 +10,7 @@ import {
   _createRootedPath,
   _resolveUrl
 } from './util';
-import {RouteConfig} from './interfaces';
+import {RouteConfig, PipelineResult} from './interfaces';
 
 /**
 * The primary class responsible for handling routing and navigation.


### PR DESCRIPTION
Flow doesn't support type aliasing so the new interface was breaking `d.ts` generation. We haven't released any new typing with this type alias.

@EisenbergEffect @davismj 