### PR TITLE
fix(router): canDeactivate correctly cancels browser history navigation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Karma Tests",
+      "sourceMaps": true,
+      "webRoot": "${workspaceRoot}",
+      "urlFilter": "http://localhost:9876/debug.html",
+      // "runtimeArgs": [
+      //     "--headless"
+      // ],
+      "pathMapping": {
+        "/": "${workspaceRoot}",
+        "/base/": "${workspaceRoot}/"
+      },
+      "sourceMapPathOverrides": {
+        "webpack:///./*": "${webRoot}/*",
+        "webpack:///src/*": "${webRoot}/*",
+        "webpack:///*": "*",
+        "webpack:///./~/*": "${webRoot}/node_modules/*",
+        "meteor://💻app/*": "${webRoot}/*"
+      }
+    }
+  ]
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -71,9 +71,14 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: ['ChromeDebugging'],
 
-
+    customLaunchers: {
+      ChromeDebugging: {
+        base: 'Chrome',
+        flags: ['--remote-debugging-port=9333']
+      }
+    },
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: false

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -266,7 +266,7 @@ function restorePreviousLocation(router) {
   if (previousLocation) {
     Promise.resolve().then(() => {
       if (router.lastHistoryMovement && !isNaN(router.lastHistoryMovement)) {
-        router.history.history.go(-router.lastHistoryMovement);
+        router.history.go(-router.lastHistoryMovement);
       }
     });
   } else if (router.fallbackRoute) {

--- a/src/app-router.js
+++ b/src/app-router.js
@@ -138,11 +138,19 @@ export class AppRouter extends Router {
         this.isNavigatingForward = true;
       } else if (this.currentNavigationTracker > navtracker) {
         this.isNavigatingBack = true;
-      } if (!navtracker) {
+      }
+      if (!navtracker) {
         navtracker = Date.now();
         this.history.setState('NavigationTracker', navtracker);
       }
       this.currentNavigationTracker = navtracker;
+
+      let historyIndex = this.history.getHistoryIndex();
+      this.lastHistoryMovement = historyIndex - this.currentHistoryIndex;
+      if (isNaN(this.lastHistoryMovement)) {
+        this.lastHistoryMovement = 0;
+      }
+      this.currentHistoryIndex = historyIndex;
 
       instruction.previousInstruction = this.currentInstruction;
 
@@ -256,7 +264,11 @@ function resolveInstruction(instruction, result, isInnerInstruction, router) {
 function restorePreviousLocation(router) {
   let previousLocation = router.history.previousLocation;
   if (previousLocation) {
-    router.navigate(router.history.previousLocation, { trigger: false, replace: true });
+    Promise.resolve().then(() => {
+      if (router.lastHistoryMovement && !isNaN(router.lastHistoryMovement)) {
+        router.history.history.go(-router.lastHistoryMovement);
+      }
+    });
   } else if (router.fallbackRoute) {
     router.navigate(router.fallbackRoute, { trigger: true, replace: true });
   } else {

--- a/src/router.js
+++ b/src/router.js
@@ -95,6 +95,16 @@ export class Router {
   currentNavigationTracker: number;
 
   /**
+  * The current index in the browser history.
+  */
+  currentHistoryIndex: number;
+
+  /**
+  * The amount of index steps in the last history navigation
+  */
+  lastHistoryMovement: number;
+
+  /**
   * The navigation models for routes that specified [[RouteConfig.nav]].
   */
   navigation: NavModel[];


### PR DESCRIPTION
Preventing a navigation with canDeactivate doesn't cancel the browser history navigation. This fix moves the browser back to the index where navigation was cancelled.

Depending on PR aurelia/history-browser#42.
Closes aurelia/router#528.