### PR TITLE
refactor(all): better discover-ability, files re-org

### DIFF
--- a/src/activation-strategy.ts
+++ b/src/activation-strategy.ts
@@ -32,16 +32,16 @@ export const activationStrategy: ActivationStrategy = {
  */
 export interface ActivationStrategy {
   /**
-  * Reuse the existing view model, without invoking Router lifecycle hooks.
-  */
+   * Reuse the existing view model, without invoking Router lifecycle hooks.
+   */
   noChange: 'no-change';
   /**
-  * Reuse the existing view model, invoking Router lifecycle hooks.
-  */
+   * Reuse the existing view model, invoking Router lifecycle hooks.
+   */
   invokeLifecycle: 'invoke-lifecycle';
   /**
-  * Replace the existing view model, invoking Router lifecycle hooks.
-  */
+   * Replace the existing view model, invoking Router lifecycle hooks.
+   */
   replace: 'replace';
 }
 

--- a/src/activation-strategy.ts
+++ b/src/activation-strategy.ts
@@ -1,0 +1,51 @@
+/**
+ * An optional interface describing the available activation strategies.
+ * @internal Used internally.
+ */
+export const enum InternalActivationStrategy {
+  /**
+   * Reuse the existing view model, without invoking Router lifecycle hooks.
+   */
+  NoChange = 'no-change',
+  /**
+   * Reuse the existing view model, invoking Router lifecycle hooks.
+   */
+  InvokeLifecycle = 'invoke-lifecycle',
+  /**
+   * Replace the existing view model, invoking Router lifecycle hooks.
+   */
+  Replace = 'replace'
+}
+
+/**
+ * The strategy to use when activating modules during navigation.
+ */
+// kept for compat reason
+export const activationStrategy: ActivationStrategy = {
+  noChange: InternalActivationStrategy.NoChange,
+  invokeLifecycle: InternalActivationStrategy.InvokeLifecycle,
+  replace: InternalActivationStrategy.Replace
+};
+
+/**
+ * An optional interface describing the available activation strategies.
+ */
+export interface ActivationStrategy {
+  /**
+  * Reuse the existing view model, without invoking Router lifecycle hooks.
+  */
+  noChange: 'no-change';
+  /**
+  * Reuse the existing view model, invoking Router lifecycle hooks.
+  */
+  invokeLifecycle: 'invoke-lifecycle';
+  /**
+  * Replace the existing view model, invoking Router lifecycle hooks.
+  */
+  replace: 'replace';
+}
+
+/**
+ * Enum like type for activation strategy built-in values
+ */
+export type ActivationStrategyType = ActivationStrategy[keyof ActivationStrategy];

--- a/src/app-router.ts
+++ b/src/app-router.ts
@@ -172,16 +172,18 @@ export class AppRouter extends Router {
       this.isNavigating = true;
 
       let navtracker: number = this.history.getState('NavigationTracker');
-      if (!navtracker && !this.currentNavigationTracker) {
+      let currentNavTracker = this.currentNavigationTracker;
+
+      if (!navtracker && !currentNavTracker) {
         this.isNavigatingFirst = true;
         this.isNavigatingNew = true;
       } else if (!navtracker) {
         this.isNavigatingNew = true;
-      } else if (!this.currentNavigationTracker) {
+      } else if (!currentNavTracker) {
         this.isNavigatingRefresh = true;
-      } else if (this.currentNavigationTracker < navtracker) {
+      } else if (currentNavTracker < navtracker) {
         this.isNavigatingForward = true;
-      } else if (this.currentNavigationTracker > navtracker) {
+      } else if (currentNavTracker > navtracker) {
         this.isNavigatingBack = true;
       } if (!navtracker) {
         navtracker = Date.now();
@@ -191,13 +193,15 @@ export class AppRouter extends Router {
 
       instruction.previousInstruction = this.currentInstruction;
 
+      let maxInstructionCount = this.maxInstructionCount;
+
       if (!instructionCount) {
         this.events.publish(RouterEvent.Processing, { instruction });
-      } else if (instructionCount === this.maxInstructionCount - 1) {
+      } else if (instructionCount === maxInstructionCount - 1) {
         logger.error(`${instructionCount + 1} navigation instructions have been attempted without success. Restoring last known good location.`);
         restorePreviousLocation(this);
         return this._dequeueInstruction(instructionCount + 1);
-      } else if (instructionCount > this.maxInstructionCount) {
+      } else if (instructionCount > maxInstructionCount) {
         throw new Error('Maximum navigation attempts exceeded. Giving up.');
       }
 

--- a/src/app-router.ts
+++ b/src/app-router.ts
@@ -19,8 +19,8 @@ declare module 'aurelia-dependency-injection' {
 const logger = LogManager.getLogger('app-router');
 
 /**
-* The main application router.
-*/
+ * The main application router.
+ */
 export class AppRouter extends Router {
 
   /**@internal */
@@ -41,9 +41,9 @@ export class AppRouter extends Router {
   }
 
   /**
-  * Fully resets the router's internal state. Primarily used internally by the framework when multiple calls to setRoot are made.
-  * Use with caution (actually, avoid using this). Do not use this to simply change your navigation model.
-  */
+   * Fully resets the router's internal state. Primarily used internally by the framework when multiple calls to setRoot are made.
+   * Use with caution (actually, avoid using this). Do not use this to simply change your navigation model.
+   */
   reset(): void {
     super.reset();
     this.maxInstructionCount = 10;
@@ -55,10 +55,10 @@ export class AppRouter extends Router {
   }
 
   /**
-  * Loads the specified URL.
-  *
-  * @param url The URL fragment to load.
-  */
+   * Loads the specified URL.
+   *
+   * @param url The URL fragment to load.
+   */
   loadUrl(url: string): Promise<NavigationInstruction> {
     return this
       ._createNavigationInstruction(url)
@@ -70,11 +70,11 @@ export class AppRouter extends Router {
   }
 
   /**
-  * Registers a viewPort to be used as a rendering target for activated routes.
-  *
-  * @param viewPort The viewPort. This is typically a <router-view/> element in Aurelia default impl
-  * @param name The name of the viewPort. 'default' if unspecified.
-  */
+   * Registers a viewPort to be used as a rendering target for activated routes.
+   *
+   * @param viewPort The viewPort. This is typically a <router-view/> element in Aurelia default impl
+   * @param name The name of the viewPort. 'default' if unspecified.
+   */
   registerViewPort(viewPort: /*ViewPort*/ any, name?: string): Promise<any> {
     // having strong typing without changing public API
     const $viewPort: ViewPort = viewPort;
@@ -119,10 +119,10 @@ export class AppRouter extends Router {
   }
 
   /**
-  * Activates the router. This instructs the router to begin listening for history changes and processing instructions.
-  *
-  * @params options The set of options to activate the router with.
-  */
+   * Activates the router. This instructs the router to begin listening for history changes and processing instructions.
+   *
+   * @params options The set of options to activate the router with.
+   */
   activate(options?: NavigationOptions): void {
     if (this.isActive) {
       return;
@@ -137,8 +137,8 @@ export class AppRouter extends Router {
   }
 
   /**
-  * Deactivates the router.
-  */
+   * Deactivates the router.
+   */
   deactivate(): void {
     this.isActive = false;
     this.history.deactivate();

--- a/src/app-router.ts
+++ b/src/app-router.ts
@@ -280,6 +280,7 @@ const resolveInstruction = (
 ): PipelineResult => {
   instruction.resolve(result);
 
+  let eventAggregator = router.events;
   let eventArgs = { instruction, result };
   if (!isInnerInstruction) {
     router.isNavigating = false;
@@ -304,10 +305,10 @@ const resolveInstruction = (
       eventName = RouterEvent.Success;
     }
 
-    router.events.publish(eventName, eventArgs);
-    router.events.publish(RouterEvent.Complete, eventArgs);
+    eventAggregator.publish(eventName, eventArgs);
+    eventAggregator.publish(RouterEvent.Complete, eventArgs);
   } else {
-    router.events.publish(RouterEvent.ChildComplete, eventArgs);
+    eventAggregator.publish(RouterEvent.ChildComplete, eventArgs);
   }
 
   return result;
@@ -316,7 +317,7 @@ const resolveInstruction = (
 const restorePreviousLocation = (router: AppRouter): void => {
   let previousLocation = router.history.previousLocation;
   if (previousLocation) {
-    router.navigate(router.history.previousLocation, { trigger: false, replace: true });
+    router.navigate(previousLocation, { trigger: false, replace: true });
   } else if (router.fallbackRoute) {
     router.navigate(router.fallbackRoute, { trigger: true, replace: true });
   } else {

--- a/src/aurelia-router.ts
+++ b/src/aurelia-router.ts
@@ -62,6 +62,6 @@ export {
 
 export { PipelineProvider } from './pipeline-provider';
 export { Pipeline } from './pipeline';
-export { RouteLoader } from './utilities-route-loading';
+export { RouteLoader } from './route-loader';
 export { RouterConfiguration } from './router-configuration';
 export { Router } from './router';

--- a/src/aurelia-router.ts
+++ b/src/aurelia-router.ts
@@ -1,5 +1,4 @@
 export {
-  ActivationStrategy,
   RoutableComponentCanActivate,
   RoutableComponentActivate,
   RoutableComponentCanDeactivate,
@@ -21,22 +20,33 @@ export {
    */
 } from './interfaces';
 export {
-  ActivateNextStep,
-  CanActivateNextStep,
-  CanDeactivatePreviousStep,
-  DeactivatePreviousStep,
   IObservable,
   IObservableConfig
-} from './activation';
+} from './utilities-activation';
 export { AppRouter } from './app-router';
 export { NavModel } from './nav-model';
 export { Redirect, RedirectToRoute, NavigationCommand, isNavigationCommand } from './navigation-commands';
-export { activationStrategy, BuildNavigationPlanStep } from './navigation-plan';
+
 export {
-  CommitChangesStep,
   NavigationInstruction,
   NavigationInstructionInit
 } from './navigation-instruction';
+
+export {
+  ActivateNextStep,
+  CanActivateNextStep,
+  CanDeactivatePreviousStep,
+  DeactivatePreviousStep
+} from './step-activation';
+
+export { CommitChangesStep } from './step-commit-changes';
+export { BuildNavigationPlanStep } from './step-build-navigation-plan';
+export { LoadRouteStep } from './step-load-route';
+
+export {
+  ActivationStrategy,
+  activationStrategy
+} from './activation-strategy';
 
 export {
   PipelineStatus
@@ -52,6 +62,6 @@ export {
 
 export { PipelineProvider } from './pipeline-provider';
 export { Pipeline } from './pipeline';
-export { RouteLoader, LoadRouteStep } from './route-loading';
+export { RouteLoader } from './utilities-route-loading';
 export { RouterConfiguration } from './router-configuration';
 export { Router } from './router';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,8 +4,9 @@ import { Router } from './router';
 import { NavModel } from './nav-model';
 import { RouterConfiguration } from './router-configuration';
 import { NavigationCommand } from './navigation-commands';
-import { IObservable } from './activation';
+import { IObservable } from './utilities-activation';
 import { PipelineStatus } from './pipeline-status';
+import { ActivationStrategyType } from './activation-strategy';
 
 /**@internal */
 declare module 'aurelia-dependency-injection' {
@@ -145,6 +146,11 @@ export interface RouteConfig {
    */
   layoutModel?: any;
 
+  /**
+   * @internal
+   */
+  hasChildRouter: boolean;
+
   [x: string]: any;
 }
 
@@ -220,28 +226,6 @@ export interface ConfiguresRouter {
   configureRouter(config: RouterConfiguration, router: Router): Promise<void> | PromiseLike<void> | void;
 }
 
-/**
-* An optional interface describing the available activation strategies.
-*/
-export interface ActivationStrategy {
-  /**
-  * Reuse the existing view model, without invoking Router lifecycle hooks.
-  */
-  noChange: 'no-change';
-  /**
-  * Reuse the existing view model, invoking Router lifecycle hooks.
-  */
-  invokeLifecycle: 'invoke-lifecycle';
-  /**
-  * Replace the existing view model, invoking Router lifecycle hooks.
-  */
-  replace: 'replace';
-}
-
-/**
- * Enum like type for activation strategy built-in values
- */
-export type ActivationStrategyType = ActivationStrategy[keyof ActivationStrategy];
 
 /**
 * A step to be run during processing of the pipeline.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -45,90 +45,90 @@ export type RouteConfigSpecifier =
   | ((instruction: NavigationInstruction) => string | RouteOrRedirectConfig | Promise<string | RouteOrRedirectConfig>);
 
 /**
-* A configuration object that describes a route.
-*/
+ * A configuration object that describes a route.
+ */
 export interface RouteConfig {
   /**
-  * The route pattern to match against incoming URL fragments, or an array of patterns.
-  */
+   * The route pattern to match against incoming URL fragments, or an array of patterns.
+   */
   route: string | string[];
 
   /**
-  * A unique name for the route that may be used to identify the route when generating URL fragments.
-  * Required when this route should support URL generation, such as with [[Router.generate]] or
-  * the route-href custom attribute.
-  */
+   * A unique name for the route that may be used to identify the route when generating URL fragments.
+   * Required when this route should support URL generation, such as with [[Router.generate]] or
+   * the route-href custom attribute.
+   */
   name?: string;
 
   /**
-  * The moduleId of the view model that should be activated for this route.
-  */
+   * The moduleId of the view model that should be activated for this route.
+   */
   moduleId?: string;
 
   /**
-  * A URL fragment to redirect to when this route is matched.
-  */
+   * A URL fragment to redirect to when this route is matched.
+   */
   redirect?: string;
 
   /**
-  * A function that can be used to dynamically select the module or modules to activate.
-  * The function is passed the current [[NavigationInstruction]], and should configure
-  * instruction.config with the desired moduleId, viewPorts, or redirect.
-  */
+   * A function that can be used to dynamically select the module or modules to activate.
+   * The function is passed the current [[NavigationInstruction]], and should configure
+   * instruction.config with the desired moduleId, viewPorts, or redirect.
+   */
   navigationStrategy?: (instruction: NavigationInstruction) => Promise<void> | void;
 
   /**
-  * The view ports to target when activating this route. If unspecified, the target moduleId is loaded
-  * into the default viewPort (the viewPort with name 'default'). The viewPorts object should have keys
-  * whose property names correspond to names used by <router-view> elements. The values should be objects
-  * specifying the moduleId to load into that viewPort.  The values may optionally include properties related to layout:
-  * `layoutView`, `layoutViewModel` and `layoutModel`.
-  */
+   * The view ports to target when activating this route. If unspecified, the target moduleId is loaded
+   * into the default viewPort (the viewPort with name 'default'). The viewPorts object should have keys
+   * whose property names correspond to names used by <router-view> elements. The values should be objects
+   * specifying the moduleId to load into that viewPort.  The values may optionally include properties related to layout:
+   * `layoutView`, `layoutViewModel` and `layoutModel`.
+   */
   viewPorts?: any;
 
   /**
-  * When specified, this route will be included in the [[Router.navigation]] nav model. Useful for
-  * dynamically generating menus or other navigation elements. When a number is specified, that value
-  * will be used as a sort order.
-  */
+   * When specified, this route will be included in the [[Router.navigation]] nav model. Useful for
+   * dynamically generating menus or other navigation elements. When a number is specified, that value
+   * will be used as a sort order.
+   */
   nav?: boolean | number;
 
   /**
-  * The URL fragment to use in nav models. If unspecified, the [[RouteConfig.route]] will be used.
-  * However, if the [[RouteConfig.route]] contains dynamic segments, this property must be specified.
-  */
+   * The URL fragment to use in nav models. If unspecified, the [[RouteConfig.route]] will be used.
+   * However, if the [[RouteConfig.route]] contains dynamic segments, this property must be specified.
+   */
   href?: string;
 
   /**
-  * Indicates that when route generation is done for this route, it should just take the literal value of the href property.
-  */
+   * Indicates that when route generation is done for this route, it should just take the literal value of the href property.
+   */
   generationUsesHref?: boolean;
 
   /**
-  * The document title to set when this route is active.
-  */
+   * The document title to set when this route is active.
+   */
   title?: string;
 
   /**
-  * Arbitrary data to attach to the route. This can be used to attached custom data needed by components
-  * like pipeline steps and activated modules.
-  */
+   * Arbitrary data to attach to the route. This can be used to attached custom data needed by components
+   * like pipeline steps and activated modules.
+   */
   settings?: any;
 
   /**
-  * The navigation model for storing and interacting with the route's navigation settings.
-  */
+   * The navigation model for storing and interacting with the route's navigation settings.
+   */
   navModel?: NavModel;
 
   /**
-  * When true is specified, this route will be case sensitive.
-  */
+   * When true is specified, this route will be case sensitive.
+   */
   caseSensitive?: boolean;
 
   /**
-  * Add to specify an activation strategy if it is always the same and you do not want that
-  * to be in your view-model code. Available values are 'replace' and 'invoke-lifecycle'.
-  */
+   * Add to specify an activation strategy if it is always the same and you do not want that
+   * to be in your view-model code. Available values are 'replace' and 'invoke-lifecycle'.
+   */
   activationStrategy?: ActivationStrategyType;
 
   /**
@@ -149,19 +149,19 @@ export interface RouteConfig {
   /**
    * @internal
    */
-  hasChildRouter: boolean;
+  hasChildRouter?: boolean;
 
   [x: string]: any;
 }
 
 /**
-* An optional interface describing the canActivate convention.
-*/
+ * An optional interface describing the canActivate convention.
+ */
 export interface RoutableComponentCanActivate {
   /**
-  * Implement this hook if you want to control whether or not your view-model can be navigated to.
-  * Return a boolean value, a promise for a boolean value, or a navigation command.
-  */
+   * Implement this hook if you want to control whether or not your view-model can be navigated to.
+   * Return a boolean value, a promise for a boolean value, or a navigation command.
+   */
   canActivate(
     params: any,
     routeConfig: RouteConfig,
@@ -170,66 +170,65 @@ export interface RoutableComponentCanActivate {
 }
 
 /**
-* An optional interface describing the activate convention.
-*/
+ * An optional interface describing the activate convention.
+ */
 export interface RoutableComponentActivate {
   /**
-  * Implement this hook if you want to perform custom logic just before your view-model is displayed.
-  * You can optionally return a promise to tell the router to wait to bind and attach the view until
-  * after you finish your work.
-  */
+   * Implement this hook if you want to perform custom logic just before your view-model is displayed.
+   * You can optionally return a promise to tell the router to wait to bind and attach the view until
+   * after you finish your work.
+   */
   activate(params: any, routeConfig: RouteConfig, navigationInstruction: NavigationInstruction): Promise<void> | PromiseLike<void> | IObservable | void;
 }
 
 /**
-* An optional interface describing the canDeactivate convention.
-*/
+ * An optional interface describing the canDeactivate convention.
+ */
 export interface RoutableComponentCanDeactivate {
   /**
-  * Implement this hook if you want to control whether or not the router can navigate away from your
-  * view-model when moving to a new route. Return a boolean value, a promise for a boolean value,
-  * or a navigation command.
-  */
+   * Implement this hook if you want to control whether or not the router can navigate away from your
+   * view-model when moving to a new route. Return a boolean value, a promise for a boolean value,
+   * or a navigation command.
+   */
   canDeactivate: () => boolean | Promise<boolean> | PromiseLike<boolean> | NavigationCommand;
 }
 
 /**
-* An optional interface describing the deactivate convention.
-*/
+ * An optional interface describing the deactivate convention.
+ */
 export interface RoutableComponentDeactivate {
   /**
-  * Implement this hook if you want to perform custom logic when your view-model is being
-  * navigated away from. You can optionally return a promise to tell the router to wait until
-  * after you finish your work.
-  */
+   * Implement this hook if you want to perform custom logic when your view-model is being
+   * navigated away from. You can optionally return a promise to tell the router to wait until
+   * after you finish your work.
+   */
   deactivate: () => Promise<void> | PromiseLike<void> | IObservable | void;
 }
 
 /**
-* An optional interface describing the determineActivationStrategy convention.
-*/
+ * An optional interface describing the determineActivationStrategy convention.
+ */
 export interface RoutableComponentDetermineActivationStrategy {
   /**
-  * Implement this hook if you want to give hints to the router about the activation strategy, when reusing
-  * a view model for different routes. Available values are 'replace' and 'invoke-lifecycle'.
-  */
+   * Implement this hook if you want to give hints to the router about the activation strategy, when reusing
+   * a view model for different routes. Available values are 'replace' and 'invoke-lifecycle'.
+   */
   determineActivationStrategy(params: any, routeConfig: RouteConfig, navigationInstruction: NavigationInstruction): ActivationStrategyType;
 }
 
 /**
-* An optional interface describing the router configuration convention.
-*/
+ * An optional interface describing the router configuration convention.
+ */
 export interface ConfiguresRouter {
   /**
-  * Implement this hook if you want to configure a router.
-  */
+   * Implement this hook if you want to configure a router.
+   */
   configureRouter(config: RouterConfiguration, router: Router): Promise<void> | PromiseLike<void> | void;
 }
 
-
 /**
-* A step to be run during processing of the pipeline.
-*/
+ * A step to be run during processing of the pipeline.
+ */
 export interface PipelineStep {
   /**
    * Execute the pipeline step. The step should invoke next(), next.complete(),
@@ -255,8 +254,8 @@ export interface IPipelineSlot {
 }
 
 /**
-* The result of a pipeline run.
-*/
+ * The result of a pipeline run.
+ */
 export interface PipelineResult {
   status: string;
   instruction: NavigationInstruction;
@@ -326,27 +325,27 @@ export type NavigationResult = boolean | Promise<PipelineResult | boolean>;
 export type LifecycleArguments = [Record<string, string>, RouteConfig, NavigationInstruction];
 
 /**
-* A callback to indicate when pipeline processing should advance to the next step
-* or be aborted.
-*/
+ * A callback to indicate when pipeline processing should advance to the next step
+ * or be aborted.
+ */
 export interface Next<T = any> {
   /**
-  * Indicates the successful completion of the pipeline step.
-  */
+   * Indicates the successful completion of the pipeline step.
+   */
   (): Promise<any>;
   /**
-  * Indicates the successful completion of the entire pipeline.
-  */
+   * Indicates the successful completion of the entire pipeline.
+   */
   complete: NextCompletionHandler<T>;
 
   /**
-  * Indicates that the pipeline should cancel processing.
-  */
+   * Indicates that the pipeline should cancel processing.
+   */
   cancel: NextCompletionHandler<T>;
 
   /**
-  * Indicates that pipeline processing has failed and should be stopped.
-  */
+   * Indicates that pipeline processing has failed and should be stopped.
+   */
   reject: NextCompletionHandler<T>;
 }
 

--- a/src/navigation-commands.ts
+++ b/src/navigation-commands.ts
@@ -55,19 +55,19 @@ export class Redirect implements NavigationCommand {
   }
 
   /**
-  * Called by the activation system to set the child router.
-  *
-  * @param router The router.
-  */
+   * Called by the activation system to set the child router.
+   *
+   * @param router The router.
+   */
   setRouter(router: Router): void {
     this.router = router;
   }
 
   /**
-  * Called by the navigation pipeline to navigate.
-  *
-  * @param appRouter The router to be redirected.
-  */
+   * Called by the navigation pipeline to navigate.
+   *
+   * @param appRouter The router to be redirected.
+   */
   navigate(appRouter: Router): void {
     let navigatingRouter = this.options.useAppRouter ? appRouter : (this.router || appRouter);
     navigatingRouter.navigate(this.url, this.options);
@@ -75,8 +75,8 @@ export class Redirect implements NavigationCommand {
 }
 
 /**
-* Used during the activation lifecycle to cause a redirect to a named route.
-*/
+ * Used during the activation lifecycle to cause a redirect to a named route.
+ */
 export class RedirectToRoute implements NavigationCommand {
 
   route: string;
@@ -103,19 +103,19 @@ export class RedirectToRoute implements NavigationCommand {
   }
 
   /**
-  * Called by the activation system to set the child router.
-  *
-  * @param router The router.
-  */
+   * Called by the activation system to set the child router.
+   *
+   * @param router The router.
+   */
   setRouter(router: Router): void {
     this.router = router;
   }
 
   /**
-  * Called by the navigation pipeline to navigate.
-  *
-  * @param appRouter The router to be redirected.
-  */
+   * Called by the navigation pipeline to navigate.
+   *
+   * @param appRouter The router to be redirected.
+   */
   navigate(appRouter: Router): void {
     let navigatingRouter = this.options.useAppRouter ? appRouter : (this.router || appRouter);
     navigatingRouter.navigateToRoute(this.route, this.params, this.options);

--- a/src/navigation-instruction.ts
+++ b/src/navigation-instruction.ts
@@ -1,6 +1,6 @@
-import { ViewPortInstruction, RouteConfig, ViewPort, LifecycleArguments, ActivationStrategyType } from './interfaces';
+import { ViewPortInstruction, RouteConfig, ViewPort, LifecycleArguments } from './interfaces';
 import { Router } from './router';
-import { activationStrategy } from './navigation-plan';
+import { activationStrategy, ActivationStrategyType } from './activation-strategy';
 
 /**
  * Initialization options for a navigation instruction
@@ -16,20 +16,6 @@ export interface NavigationInstructionInit {
   router: Router;
   options?: Object;
   plan?: Record<string, /*ViewPortInstruction*/any>;
-}
-
-/**
- * A pipeline step for instructing a piepline to commit changes on a navigation instruction
- */
-export class CommitChangesStep {
-  run(navigationInstruction: NavigationInstruction, next: Function): Promise<any> {
-    return navigationInstruction
-      ._commitChanges(/*wait to swap?*/true)
-      .then(() => {
-        navigationInstruction._updateTitle();
-        return next();
-      });
-  }
 }
 
 /**
@@ -149,7 +135,7 @@ export class NavigationInstruction {
   addViewPortInstruction(name: string, strategy: ActivationStrategyType, moduleId: string, component: any): /*ViewPortInstruction*/ any {
     const lifecycleArgs = this.lifecycleArgs;
     const config: RouteConfig = Object.assign({}, lifecycleArgs[1], { currentViewPort: name });
-    const viewportInstruction = this.viewPortInstructions[name] = {
+    const viewportInstruction: ViewPortInstruction = this.viewPortInstructions[name] = {
       name: name,
       strategy: strategy,
       moduleId: moduleId,

--- a/src/navigation-plan.ts
+++ b/src/navigation-plan.ts
@@ -110,7 +110,7 @@ export const buildTransitionPlans = (
 
     let nextViewPortConfig = viewPortName in newInstructionConfig.viewPorts ? newInstructionConfig.viewPorts[viewPortName] : prevViewPortInstruction;
 
-    if (nextViewPortConfig.moduleId === null && viewPortName in currentInstruction.router.viewPortDefaults) {
+    if (nextViewPortConfig.moduleId === null && viewPortName in defaultViewPortConfigs) {
       nextViewPortConfig = defaultViewPortConfigs[viewPortName];
     }
 

--- a/src/navigation-plan.ts
+++ b/src/navigation-plan.ts
@@ -19,15 +19,17 @@ export function _buildNavigationPlan(
   }
 
   const prevInstruction = instruction.previousInstruction;
-  const viewPortPlans: ViewPortPlansRecord = {};
   const defaultViewPortConfigs = instruction.router.viewPortDefaults;
 
   if (prevInstruction) {
-    return buildTransitionPlans(instruction, prevInstruction, viewPortPlans, defaultViewPortConfigs, forceLifecycleMinimum);
+    return buildTransitionPlans(instruction, prevInstruction, defaultViewPortConfigs, forceLifecycleMinimum);
   }
 
-  for (let viewPortName in config.viewPorts) {
-    let viewPortConfig = config.viewPorts[viewPortName];
+  // first navigation, only need to prepare a few information for each viewport plan
+  const viewPortPlans: ViewPortPlansRecord = {};
+  let viewPortConfigs = config.viewPorts;
+  for (let viewPortName in viewPortConfigs) {
+    let viewPortConfig = viewPortConfigs[viewPortName];
     if (viewPortConfig.moduleId === null && viewPortName in defaultViewPortConfigs) {
       viewPortConfig = defaultViewPortConfigs[viewPortName];
     }
@@ -92,11 +94,11 @@ export const buildRedirectPlan = (instruction: NavigationInstruction) => {
 export const buildTransitionPlans = (
   currentInstruction: NavigationInstruction,
   previousInstruction: NavigationInstruction,
-  viewPortPlans: ViewPortPlansRecord,
   defaultViewPortConfigs: Record<string, ViewPortInstruction>,
   forceLifecycleMinimum?: boolean
 ): Promise<ViewPortPlansRecord> => {
 
+  let viewPortPlans: ViewPortPlansRecord = {};
   let newInstructionConfig = currentInstruction.config;
   let hasNewParams = hasDifferentParameterValues(previousInstruction, currentInstruction);
   let pending: Promise<void>[] = [];

--- a/src/pipeline-provider.ts
+++ b/src/pipeline-provider.ts
@@ -131,6 +131,6 @@ export class PipelineProvider {
 }
 
 /**@internal */
-const createPipelineSlot = (container: Container, name: string, alias?: string): PipelineSlot => {
+const createPipelineSlot = (container: Container, name: PipelineSlotName, alias?: string): PipelineSlot => {
   return new PipelineSlot(container, name, alias);
 };

--- a/src/pipeline-provider.ts
+++ b/src/pipeline-provider.ts
@@ -33,8 +33,8 @@ class PipelineSlot implements IPipelineSlot {
 }
 
 /**
-* Class responsible for creating the navigation pipeline.
-*/
+ * Class responsible for creating the navigation pipeline.
+ */
 export class PipelineProvider {
 
   /**@internal */
@@ -50,15 +50,15 @@ export class PipelineProvider {
       BuildNavigationPlanStep,
       CanDeactivatePreviousStep, // optional
       LoadRouteStep,
-      this._createPipelineSlot(PipelineSlotName.Authorize),
+      createPipelineSlot(container, PipelineSlotName.Authorize),
       CanActivateNextStep, // optional
-      this._createPipelineSlot(PipelineSlotName.PreActivate, 'modelbind'),
+      createPipelineSlot(container, PipelineSlotName.PreActivate, 'modelbind'),
       // NOTE: app state changes start below - point of no return
       DeactivatePreviousStep, // optional
       ActivateNextStep, // optional
-      this._createPipelineSlot(PipelineSlotName.PreRender, 'precommit'),
+      createPipelineSlot(container, PipelineSlotName.PreRender, 'precommit'),
       CommitChangesStep,
-      this._createPipelineSlot(PipelineSlotName.PostRender, 'postcomplete')
+      createPipelineSlot(container, PipelineSlotName.PostRender, 'postcomplete')
     ];
   }
 
@@ -128,9 +128,9 @@ export class PipelineProvider {
     this._clearSteps(PipelineSlotName.PreRender);
     this._clearSteps(PipelineSlotName.PostRender);
   }
-
-  /**@internal */
-  _createPipelineSlot(name: string, alias?: string): PipelineSlot {
-    return new PipelineSlot(this.container, name, alias);
-  }
 }
+
+/**@internal */
+const createPipelineSlot = (container: Container, name: string, alias?: string): PipelineSlot => {
+  return new PipelineSlot(container, name, alias);
+};

--- a/src/pipeline-provider.ts
+++ b/src/pipeline-provider.ts
@@ -1,14 +1,9 @@
 import { Container } from 'aurelia-dependency-injection';
 import { Pipeline } from './pipeline';
-import { BuildNavigationPlanStep } from './navigation-plan';
-import { LoadRouteStep } from './route-loading';
-import { CommitChangesStep } from './navigation-instruction';
-import {
-  CanDeactivatePreviousStep,
-  CanActivateNextStep,
-  DeactivatePreviousStep,
-  ActivateNextStep
-} from './activation';
+import { BuildNavigationPlanStep } from './step-build-navigation-plan';
+import { LoadRouteStep } from './step-load-route';
+import { CommitChangesStep } from './step-commit-changes';
+import { CanDeactivatePreviousStep, CanActivateNextStep, DeactivatePreviousStep, ActivateNextStep } from './step-activation';
 import { PipelineStep, StepRunnerFunction, IPipelineSlot } from './interfaces';
 import { PipelineSlotName } from './pipeline-slot-name';
 
@@ -68,8 +63,8 @@ export class PipelineProvider {
   }
 
   /**
-  * Create the navigation pipeline.
-  */
+   * Create the navigation pipeline.
+   */
   createPipeline(useCanDeactivateStep: boolean = true): Pipeline {
     let pipeline = new Pipeline();
     this.steps.forEach(step => {
@@ -87,14 +82,15 @@ export class PipelineProvider {
   }
 
   /**
-  * Adds a step into the pipeline at a known slot location.
-  */
+   * Adds a step into the pipeline at a known slot location.
+   */
   addStep(name: string, step: PipelineStep | Function): void {
     let found = this._findStep(name);
     if (found) {
+      let slotSteps = found.steps;
       // prevent duplicates
-      if (!found.steps.includes(step)) {
-        found.steps.push(step);
+      if (!slotSteps.includes(step)) {
+        slotSteps.push(step);
       }
     } else {
       throw new Error(`Invalid pipeline slot name: ${name}.`);
@@ -107,14 +103,14 @@ export class PipelineProvider {
   removeStep(name: string, step: PipelineStep): void {
     let slot = this._findStep(name);
     if (slot) {
-      let steps = slot.steps;
-      steps.splice(steps.indexOf(step), 1);
+      let slotSteps = slot.steps;
+      slotSteps.splice(slotSteps.indexOf(step), 1);
     }
   }
 
   /**
-   * @internal
    * Clears all steps from a slot in the pipeline
+   * @internal
    */
   _clearSteps(name: string = ''): void {
     let slot = this._findStep(name);
@@ -127,10 +123,10 @@ export class PipelineProvider {
    * Resets all pipeline slots
    */
   reset(): void {
-    this._clearSteps('authorize');
-    this._clearSteps('preActivate');
-    this._clearSteps('preRender');
-    this._clearSteps('postRender');
+    this._clearSteps(PipelineSlotName.Authorize);
+    this._clearSteps(PipelineSlotName.PreActivate);
+    this._clearSteps(PipelineSlotName.PreRender);
+    this._clearSteps(PipelineSlotName.PostRender);
   }
 
   /**@internal */

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -3,20 +3,20 @@ import { NavigationInstruction } from './navigation-instruction';
 import { createNextFn } from './next';
 
 /**
-* The class responsible for managing and processing the navigation pipeline.
-*/
+ * The class responsible for managing and processing the navigation pipeline.
+ */
 export class Pipeline {
   /**
-  * The pipeline steps. And steps added via addStep will be converted to a function
-  * The actualy running functions with correct step contexts of this pipeline
-  */
+   * The pipeline steps. And steps added via addStep will be converted to a function
+   * The actualy running functions with correct step contexts of this pipeline
+   */
   steps: StepRunnerFunction[] = [];
 
   /**
-  * Adds a step to the pipeline.
-  *
-  * @param step The pipeline step.
-  */
+   * Adds a step to the pipeline.
+   *
+   * @param step The pipeline step.
+   */
   addStep(step: StepRunnerFunction | PipelineStep | IPipelineSlot): Pipeline {
     let run;
 
@@ -41,10 +41,10 @@ export class Pipeline {
   }
 
   /**
-  * Runs the pipeline.
-  *
-  * @param instruction The navigation instruction to process.
-  */
+   * Runs the pipeline.
+   *
+   * @param instruction The navigation instruction to process.
+   */
   run(instruction: NavigationInstruction): Promise<PipelineResult> {
     const nextFn = createNextFn(instruction, this.steps);
     return nextFn();

--- a/src/route-loader.ts
+++ b/src/route-loader.ts
@@ -1,0 +1,18 @@
+import { RouteConfig } from './interfaces';
+import { NavigationInstruction } from './navigation-instruction';
+import { Router } from './router';
+
+/**
+ * Abstract class that is responsible for loading view / view model from a route config
+ * The default implementation can be found in `aurelia-templating-router`
+ */
+export class RouteLoader {
+  /**
+   * Load a route config based on its viewmodel / view configuration
+   */
+  // return typing: return typings used to be never
+  // as it was a throw. Changing it to Promise<any> should not cause any issues
+  loadRoute(router: Router, config: RouteConfig, navigationInstruction: NavigationInstruction): Promise</*ViewPortInstruction*/any> {
+    throw new Error('Route loaders must implement "loadRoute(router, config, navigationInstruction)".');
+  }
+}

--- a/src/router-configuration.ts
+++ b/src/router-configuration.ts
@@ -102,7 +102,7 @@ export class RouterConfiguration {
    */
   map(route: RouteConfig | RouteConfig[]): RouterConfiguration {
     if (Array.isArray(route)) {
-      route.forEach(this.map.bind(this));
+      route.forEach(r => this.map(r));
       return this;
     }
 
@@ -169,24 +169,26 @@ export class RouterConfiguration {
       instructions[i](router);
     }
 
-    if (this.title) {
-      router.title = this.title;
+    let { title, titleSeparator, unknownRouteConfig, _fallbackRoute, viewPortDefaults } = this;
+
+    if (title) {
+      router.title = title;
     }
 
-    if (this.titleSeparator) {
-      router.titleSeparator = this.titleSeparator;
+    if (titleSeparator) {
+      router.titleSeparator = titleSeparator;
     }
 
-    if (this.unknownRouteConfig) {
-      router.handleUnknownRoutes(this.unknownRouteConfig);
+    if (unknownRouteConfig) {
+      router.handleUnknownRoutes(unknownRouteConfig);
     }
 
-    if (this._fallbackRoute) {
-      router.fallbackRoute = this._fallbackRoute;
+    if (_fallbackRoute) {
+      router.fallbackRoute = _fallbackRoute;
     }
 
-    if (this.viewPortDefaults) {
-      router.useViewPortDefaults(this.viewPortDefaults);
+    if (viewPortDefaults) {
+      router.useViewPortDefaults(viewPortDefaults);
     }
 
     Object.assign(router.options, this.options);

--- a/src/router-configuration.ts
+++ b/src/router-configuration.ts
@@ -29,12 +29,12 @@ export class RouterConfiguration {
   _fallbackRoute: string;
 
   /**
-  * Adds a step to be run during the [[Router]]'s navigation pipeline.
-  *
-  * @param name The name of the pipeline slot to insert the step into.
-  * @param step The pipeline step.
-  * @chainable
-  */
+   * Adds a step to be run during the [[Router]]'s navigation pipeline.
+   *
+   * @param name The name of the pipeline slot to insert the step into.
+   * @param step The pipeline step.
+   * @chainable
+   */
   addPipelineStep(name: string, step: Function | PipelineStep): RouterConfiguration {
     if (step === null || step === undefined) {
       throw new Error('Pipeline step cannot be null or undefined.');
@@ -44,62 +44,62 @@ export class RouterConfiguration {
   }
 
   /**
-  * Adds a step to be run during the [[Router]]'s authorize pipeline slot.
-  *
-  * @param step The pipeline step.
-  * @chainable
-  */
+   * Adds a step to be run during the [[Router]]'s authorize pipeline slot.
+   *
+   * @param step The pipeline step.
+   * @chainable
+   */
   addAuthorizeStep(step: Function | PipelineStep): RouterConfiguration {
     return this.addPipelineStep(PipelineSlotName.Authorize, step);
   }
 
   /**
-  * Adds a step to be run during the [[Router]]'s preActivate pipeline slot.
-  *
-  * @param step The pipeline step.
-  * @chainable
-  */
+   * Adds a step to be run during the [[Router]]'s preActivate pipeline slot.
+   *
+   * @param step The pipeline step.
+   * @chainable
+   */
   addPreActivateStep(step: Function | PipelineStep): RouterConfiguration {
     return this.addPipelineStep(PipelineSlotName.PreActivate, step);
   }
 
   /**
-  * Adds a step to be run during the [[Router]]'s preRender pipeline slot.
-  *
-  * @param step The pipeline step.
-  * @chainable
-  */
+   * Adds a step to be run during the [[Router]]'s preRender pipeline slot.
+   *
+   * @param step The pipeline step.
+   * @chainable
+   */
   addPreRenderStep(step: Function | PipelineStep): RouterConfiguration {
     return this.addPipelineStep(PipelineSlotName.PreRender, step);
   }
 
   /**
-  * Adds a step to be run during the [[Router]]'s postRender pipeline slot.
-  *
-  * @param step The pipeline step.
-  * @chainable
-  */
+   * Adds a step to be run during the [[Router]]'s postRender pipeline slot.
+   *
+   * @param step The pipeline step.
+   * @chainable
+   */
   addPostRenderStep(step: Function | PipelineStep): RouterConfiguration {
     return this.addPipelineStep(PipelineSlotName.PostRender, step);
   }
 
   /**
-  * Configures a route that will be used if there is no previous location available on navigation cancellation.
-  *
-  * @param fragment The URL fragment to use as the navigation destination.
-  * @chainable
-  */
+   * Configures a route that will be used if there is no previous location available on navigation cancellation.
+   *
+   * @param fragment The URL fragment to use as the navigation destination.
+   * @chainable
+   */
   fallbackRoute(fragment: string): RouterConfiguration {
     this._fallbackRoute = fragment;
     return this;
   }
 
   /**
-  * Maps one or more routes to be registered with the router.
-  *
-  * @param route The [[RouteConfig]] to map, or an array of [[RouteConfig]] to map.
-  * @chainable
-  */
+   * Maps one or more routes to be registered with the router.
+   *
+   * @param route The [[RouteConfig]] to map, or an array of [[RouteConfig]] to map.
+   * @chainable
+   */
   map(route: RouteConfig | RouteConfig[]): RouterConfiguration {
     if (Array.isArray(route)) {
       route.forEach(this.map.bind(this));
@@ -122,11 +122,11 @@ export class RouterConfiguration {
   }
 
   /**
-  * Maps a single route to be registered with the router.
-  *
-  * @param route The [[RouteConfig]] to map.
-  * @chainable
-  */
+   * Maps a single route to be registered with the router.
+   *
+   * @param route The [[RouteConfig]] to map.
+   * @chainable
+   */
   mapRoute(config: RouteConfig): RouterConfiguration {
     this.instructions.push(router => {
       let routeConfigs = _ensureArrayWithSingleRoutePerConfig(config);
@@ -147,22 +147,22 @@ export class RouterConfiguration {
   }
 
   /**
-  * Registers an unknown route handler to be run when the URL fragment doesn't match any registered routes.
-  *
-  * @param config A string containing a moduleId to load, or a [[RouteConfig]], or a function that takes the
-  *  [[NavigationInstruction]] and selects a moduleId to load.
-  * @chainable
-  */
+   * Registers an unknown route handler to be run when the URL fragment doesn't match any registered routes.
+   *
+   * @param config A string containing a moduleId to load, or a [[RouteConfig]], or a function that takes the
+   *  [[NavigationInstruction]] and selects a moduleId to load.
+   * @chainable
+   */
   mapUnknownRoutes(config: RouteConfigSpecifier): RouterConfiguration {
     this.unknownRouteConfig = config;
     return this;
   }
 
   /**
-  * Applies the current configuration to the specified [[Router]].
-  *
-  * @param router The [[Router]] to apply the configuration to.
-  */
+   * Applies the current configuration to the specified [[Router]].
+   *
+   * @param router The [[Router]] to apply the configuration to.
+   */
   exportToRouter(router: Router): void {
     let instructions = this.instructions;
     for (let i = 0, ii = instructions.length; i < ii; ++i) {
@@ -192,13 +192,14 @@ export class RouterConfiguration {
     Object.assign(router.options, this.options);
 
     let pipelineSteps = this.pipelineSteps;
-    if (pipelineSteps.length) {
+    let pipelineStepCount = pipelineSteps.length;
+    if (pipelineStepCount) {
       if (!router.isRoot) {
         throw new Error('Pipeline steps can only be added to the root router');
       }
 
       let pipelineProvider = router.pipelineProvider;
-      for (let i = 0, ii = pipelineSteps.length; i < ii; ++i) {
+      for (let i = 0, ii = pipelineStepCount; i < ii; ++i) {
         let { name, step } = pipelineSteps[i];
         pipelineProvider.addStep(name, step);
       }

--- a/src/router.ts
+++ b/src/router.ts
@@ -90,80 +90,80 @@ export class Router {
   titleSeparator: string | undefined;
 
   /**
-  * True if the [[Router]] has been configured.
-  */
+   * True if the [[Router]] has been configured.
+   */
   isConfigured: boolean;
 
   /**
-  * True if the [[Router]] is currently processing a navigation.
-  */
+   * True if the [[Router]] is currently processing a navigation.
+   */
   isNavigating: boolean;
 
   /**
-  * True if the [[Router]] is navigating due to explicit call to navigate function(s).
-  */
+   * True if the [[Router]] is navigating due to explicit call to navigate function(s).
+   */
   isExplicitNavigation: boolean;
 
   /**
-  * True if the [[Router]] is navigating due to explicit call to navigateBack function.
-  */
+   * True if the [[Router]] is navigating due to explicit call to navigateBack function.
+   */
   isExplicitNavigationBack: boolean;
 
   /**
-  * True if the [[Router]] is navigating into the app for the first time in the browser session.
-  */
+   * True if the [[Router]] is navigating into the app for the first time in the browser session.
+   */
   isNavigatingFirst: boolean;
 
   /**
-  * True if the [[Router]] is navigating to a page instance not in the browser session history.
-  */
+   * True if the [[Router]] is navigating to a page instance not in the browser session history.
+   */
   isNavigatingNew: boolean;
 
   /**
-  * True if the [[Router]] is navigating forward in the browser session history.
-  */
+   * True if the [[Router]] is navigating forward in the browser session history.
+   */
   isNavigatingForward: boolean;
 
   /**
-  * True if the [[Router]] is navigating back in the browser session history.
-  */
+   * True if the [[Router]] is navigating back in the browser session history.
+   */
   isNavigatingBack: boolean;
 
   /**
-  * True if the [[Router]] is navigating due to a browser refresh.
-  */
+   * True if the [[Router]] is navigating due to a browser refresh.
+   */
   isNavigatingRefresh: boolean;
 
   /**
-  * True if the previous instruction successfully completed the CanDeactivatePreviousStep in the current navigation.
-  */
+   * True if the previous instruction successfully completed the CanDeactivatePreviousStep in the current navigation.
+   */
   couldDeactivate: boolean;
 
   /**
-  * The currently active navigation tracker.
-  */
+   * The currently active navigation tracker.
+   */
   currentNavigationTracker: number;
 
   /**
-  * The navigation models for routes that specified [[RouteConfig.nav]].
-  */
+   * The navigation models for routes that specified [[RouteConfig.nav]].
+   */
   navigation: NavModel[];
 
   /**
-  * The currently active navigation instruction.
-  */
+   * The currently active navigation instruction.
+   */
   currentInstruction: NavigationInstruction;
 
   /**
-  * The parent router, or null if this instance is not a child router.
-  */
+   * The parent router, or null if this instance is not a child router.
+   */
   parent: Router = null;
 
   options: any = {};
 
   /**
-  * The defaults used when a viewport lacks specified content
-  */
+   * The defaults used when a viewport lacks specified content
+   */
   viewPortDefaults: Record<string, any> = {};
 
   /**@internal */
@@ -184,10 +184,10 @@ export class Router {
   _resolveConfiguredPromise: (value?: any) => void;
 
   /**
-  * Extension point to transform the document title before it is built and displayed.
-  * By default, child routers delegate to the parent router, and the app router
-  * returns the title unchanged.
-  */
+   * Extension point to transform the document title before it is built and displayed.
+   * By default, child routers delegate to the parent router, and the app router
+   * returns the title unchanged.
+   */
   transformTitle: (title: string) => string = (title: string) => {
     if (this.parent) {
       return this.parent.transformTitle(title);
@@ -196,9 +196,9 @@ export class Router {
   }
 
   /**
-  * @param container The [[Container]] to use when child routers.
-  * @param history The [[History]] implementation to delegate navigation requests to.
-  */
+   * @param container The [[Container]] to use when child routers.
+   * @param history The [[History]] implementation to delegate navigation requests to.
+   */
   constructor(container: Container, history: History) {
     this.container = container;
     this.history = history;
@@ -206,9 +206,9 @@ export class Router {
   }
 
   /**
-  * Fully resets the router's internal state. Primarily used internally by the framework when multiple calls to setRoot are made.
-  * Use with caution (actually, avoid using this). Do not use this to simply change your navigation model.
-  */
+   * Fully resets the router's internal state. Primarily used internally by the framework when multiple calls to setRoot are made.
+   * Use with caution (actually, avoid using this). Do not use this to simply change your navigation model.
+   */
   reset() {
     this.viewPorts = {};
     this.routes = [];
@@ -235,35 +235,35 @@ export class Router {
   }
 
   /**
-  * Gets a value indicating whether or not this [[Router]] is the root in the router tree. I.e., it has no parent.
-  */
+   * Gets a value indicating whether or not this [[Router]] is the root in the router tree. I.e., it has no parent.
+   */
   get isRoot(): boolean {
     return !this.parent;
   }
 
   /**
-  * Registers a viewPort to be used as a rendering target for activated routes.
-  *
-  * @param viewPort The viewPort.
-  * @param name The name of the viewPort. 'default' if unspecified.
-  */
+   * Registers a viewPort to be used as a rendering target for activated routes.
+   *
+   * @param viewPort The viewPort.
+   * @param name The name of the viewPort. 'default' if unspecified.
+   */
   registerViewPort(viewPort: /*ViewPort*/any, name?: string): void {
     name = name || 'default';
     this.viewPorts[name] = viewPort;
   }
 
   /**
-  * Returns a Promise that resolves when the router is configured.
-  */
+   * Returns a Promise that resolves when the router is configured.
+   */
   ensureConfigured(): Promise<void> {
     return this._configuredPromise;
   }
 
   /**
-  * Configures the router.
-  *
-  * @param callbackOrConfig The [[RouterConfiguration]] or a callback that takes a [[RouterConfiguration]].
-  */
+   * Configures the router.
+   *
+   * @param callbackOrConfig The [[RouterConfiguration]] or a callback that takes a [[RouterConfiguration]].
+   */
   configure(callbackOrConfig: RouterConfiguration | ((config: RouterConfiguration) => RouterConfiguration)): Promise<void> {
     this.isConfigured = true;
 
@@ -288,11 +288,11 @@ export class Router {
   }
 
   /**
-  * Navigates to a new location.
-  *
-  * @param fragment The URL fragment to use as the navigation destination.
-  * @param options The navigation options.
-  */
+   * Navigates to a new location.
+   *
+   * @param fragment The URL fragment to use as the navigation destination.
+   * @param options The navigation options.
+   */
   navigate(fragment: string, options?: NavigationOptions): boolean {
     if (!this.isConfigured && this.parent) {
       return this.parent.navigate(fragment, options);
@@ -303,21 +303,21 @@ export class Router {
   }
 
   /**
-  * Navigates to a new location corresponding to the route and params specified. Equivallent to [[Router.generate]] followed
-  * by [[Router.navigate]].
-  *
-  * @param route The name of the route to use when generating the navigation location.
-  * @param params The route parameters to be used when populating the route pattern.
-  * @param options The navigation options.
-  */
+   * Navigates to a new location corresponding to the route and params specified. Equivallent to [[Router.generate]] followed
+   * by [[Router.navigate]].
+   *
+   * @param route The name of the route to use when generating the navigation location.
+   * @param params The route parameters to be used when populating the route pattern.
+   * @param options The navigation options.
+   */
   navigateToRoute(route: string, params?: any, options?: NavigationOptions): boolean {
     let path = this.generate(route, params);
     return this.navigate(path, options);
   }
 
   /**
-  * Navigates back to the most recent location in history.
-  */
+   * Navigates back to the most recent location in history.
+   */
   navigateBack(): void {
     this.isExplicitNavigationBack = true;
     this.history.navigateBack();
@@ -336,13 +336,13 @@ export class Router {
   }
 
   /**
-  * Generates a URL fragment matching the specified route pattern.
-  *
-  * @param name The name of the route whose pattern should be used to generate the fragment.
-  * @param params The route params to be used to populate the route pattern.
-  * @param options If options.absolute = true, then absolute url will be generated; otherwise, it will be relative url.
-  * @returns {string} A string containing the generated URL fragment.
-  */
+   * Generates a URL fragment matching the specified route pattern.
+   *
+   * @param name The name of the route whose pattern should be used to generate the fragment.
+   * @param params The route params to be used to populate the route pattern.
+   * @param options If options.absolute = true, then absolute url will be generated; otherwise, it will be relative url.
+   * @returns {string} A string containing the generated URL fragment.
+   */
   generate(nameOrRoute: string | RouteConfig, params: any = {}, options: any = {}): string {
     // A child recognizer generates routes for potential child routes. Any potential child route is added
     // to the childRoute property of params for the childRouter to recognize. When generating routes, we
@@ -720,17 +720,19 @@ export const evaluateNavigationStrategy = (
   evaluator: Function,
   context?: any
 ): Promise<NavigationInstruction> => {
-  return Promise.resolve(evaluator.call(context, instruction)).then(() => {
-    if (!('viewPorts' in instruction.config)) {
-      instruction.config.viewPorts = {
-        'default': {
-          moduleId: instruction.config.moduleId
-        }
-      };
-    }
+  return Promise
+    .resolve(evaluator.call(context, instruction))
+    .then(() => {
+      if (!('viewPorts' in instruction.config)) {
+        instruction.config.viewPorts = {
+          'default': {
+            moduleId: instruction.config.moduleId
+          }
+        };
+      }
 
-    return instruction;
-  });
+      return instruction;
+    });
 };
 
 interface IRouteRecognizationResults extends Array<RecognizedRoute> {

--- a/src/router.ts
+++ b/src/router.ts
@@ -10,7 +10,7 @@ import {
   _createRootedPath,
   _resolveUrl
 } from './util';
-import { RouteConfig, NavigationResult, RouteConfigSpecifier, ViewPort, ViewPortInstruction } from './interfaces';
+import { RouteConfig, RouteConfigSpecifier, ViewPortInstruction } from './interfaces';
 import { PipelineProvider } from './pipeline-provider';
 
 /**@internal */

--- a/src/router.ts
+++ b/src/router.ts
@@ -361,10 +361,10 @@ export class Router {
   }
 
   /**
-  * Creates a [[NavModel]] for the specified route config.
-  *
-  * @param config The route config.
-  */
+   * Creates a [[NavModel]] for the specified route config.
+   *
+   * @param config The route config.
+   */
   createNavModel(config: RouteConfig): NavModel {
     let navModel = new NavModel(
       this,
@@ -382,11 +382,11 @@ export class Router {
   }
 
   /**
-  * Registers a new route with the router.
-  *
-  * @param config The [[RouteConfig]].
-  * @param navModel The [[NavModel]] to use for the route. May be omitted for single-pattern routes.
-  */
+   * Registers a new route with the router.
+   *
+   * @param config The [[RouteConfig]].
+   * @param navModel The [[NavModel]] to use for the route. May be omitted for single-pattern routes.
+   */
   addRoute(config: RouteConfig, navModel?: NavModel): void {
     if (Array.isArray(config.route)) {
       let routeConfigs = _ensureArrayWithSingleRoutePerConfig(config);
@@ -467,28 +467,28 @@ export class Router {
   }
 
   /**
-  * Gets a value indicating whether or not this [[Router]] or one of its ancestors has a route registered with the specified name.
-  *
-  * @param name The name of the route to check.
-  */
+   * Gets a value indicating whether or not this [[Router]] or one of its ancestors has a route registered with the specified name.
+   *
+   * @param name The name of the route to check.
+   */
   hasRoute(name: string): boolean {
     return !!(this._recognizer.hasRoute(name) || this.parent && this.parent.hasRoute(name));
   }
 
   /**
-  * Gets a value indicating whether or not this [[Router]] has a route registered with the specified name.
-  *
-  * @param name The name of the route to check.
-  */
+   * Gets a value indicating whether or not this [[Router]] has a route registered with the specified name.
+   *
+   * @param name The name of the route to check.
+   */
   hasOwnRoute(name: string): boolean {
     return this._recognizer.hasRoute(name);
   }
 
   /**
-  * Register a handler to use when the incoming URL fragment doesn't match any registered routes.
-  *
-  * @param config The moduleId, or a function that selects the moduleId, or a [[RouteConfig]].
-  */
+   * Register a handler to use when the incoming URL fragment doesn't match any registered routes.
+   *
+   * @param config The moduleId, or a function that selects the moduleId, or a [[RouteConfig]].
+   */
   handleUnknownRoutes(config?: RouteConfigSpecifier): void {
     if (!config) {
       throw new Error('Invalid unknown route handler');
@@ -505,8 +505,8 @@ export class Router {
   }
 
   /**
-  * Updates the document title using the current navigation instruction.
-  */
+   * Updates the document title using the current navigation instruction.
+   */
   updateTitle(): void {
     let parentRouter = this.parent;
     if (parentRouter) {
@@ -521,9 +521,9 @@ export class Router {
   }
 
   /**
-  * Updates the navigation routes with hrefs relative to the current location.
-  * Note: This method will likely move to a plugin in a future release.
-  */
+   * Updates the navigation routes with hrefs relative to the current location.
+   * Note: This method will likely move to a plugin in a future release.
+   */
   refreshNavigation(): void {
     let nav = this.navigation;
 

--- a/src/step-activation.ts
+++ b/src/step-activation.ts
@@ -1,6 +1,7 @@
 import { Next } from './interfaces';
 import { NavigationInstruction } from './navigation-instruction';
 import { processDeactivatable, processActivatable } from './utilities-activation';
+
 /**
  * A pipeline step responsible for finding and activating method `canDeactivate` on a view model of a route
  */

--- a/src/step-activation.ts
+++ b/src/step-activation.ts
@@ -1,0 +1,38 @@
+import { Next } from './interfaces';
+import { NavigationInstruction } from './navigation-instruction';
+import { processDeactivatable, processActivatable } from './utilities-activation';
+/**
+ * A pipeline step responsible for finding and activating method `canDeactivate` on a view model of a route
+ */
+export class CanDeactivatePreviousStep {
+  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
+    return processDeactivatable(navigationInstruction, 'canDeactivate', next);
+  }
+}
+
+/**
+ * A pipeline step responsible for finding and activating method `canActivate` on a view model of a route
+ */
+export class CanActivateNextStep {
+  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
+    return processActivatable(navigationInstruction, 'canActivate', next);
+  }
+}
+
+/**
+ * A pipeline step responsible for finding and activating method `deactivate` on a view model of a route
+ */
+export class DeactivatePreviousStep {
+  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
+    return processDeactivatable(navigationInstruction, 'deactivate', next, true);
+  }
+}
+
+/**
+ * A pipeline step responsible for finding and activating method `activate` on a view model of a route
+ */
+export class ActivateNextStep {
+  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
+    return processActivatable(navigationInstruction, 'activate', next, true);
+  }
+}

--- a/src/step-build-navigation-plan.ts
+++ b/src/step-build-navigation-plan.ts
@@ -1,0 +1,22 @@
+import { Next } from './interfaces';
+import { Redirect } from './navigation-commands';
+import { NavigationInstruction } from './navigation-instruction';
+import { _buildNavigationPlan } from './navigation-plan';
+
+/**
+ * Transform a navigation instruction into viewport plan record object,
+ * or a redirect request if user viewmodel demands
+ */
+export class BuildNavigationPlanStep {
+  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
+    return _buildNavigationPlan(navigationInstruction)
+      .then(plan => {
+        if (plan instanceof Redirect) {
+          return next.cancel(plan);
+        }
+        navigationInstruction.plan = plan;
+        return next();
+      })
+      .catch(next.cancel);
+  }
+}

--- a/src/step-commit-changes.ts
+++ b/src/step-commit-changes.ts
@@ -1,0 +1,15 @@
+import { NavigationInstruction } from './navigation-instruction';
+
+/**
+ * A pipeline step for instructing a piepline to commit changes on a navigation instruction
+ */
+export class CommitChangesStep {
+  run(navigationInstruction: NavigationInstruction, next: Function): Promise<any> {
+    return navigationInstruction
+      ._commitChanges(/*wait to swap?*/ true)
+      .then(() => {
+        navigationInstruction._updateTitle();
+        return next();
+      });
+  }
+}

--- a/src/step-load-route.ts
+++ b/src/step-load-route.ts
@@ -1,6 +1,7 @@
 import { Next } from './interfaces';
 import { NavigationInstruction } from './navigation-instruction';
-import { RouteLoader, loadNewRoute } from './utilities-route-loading';
+import { loadNewRoute } from './utilities-route-loading';
+import { RouteLoader } from './route-loader';
 /**
  * A pipeline step responsible for loading a route config of a navigation instruction
  */

--- a/src/step-load-route.ts
+++ b/src/step-load-route.ts
@@ -1,0 +1,25 @@
+import { Next } from './interfaces';
+import { NavigationInstruction } from './navigation-instruction';
+import { RouteLoader, loadNewRoute } from './utilities-route-loading';
+/**
+ * A pipeline step responsible for loading a route config of a navigation instruction
+ */
+export class LoadRouteStep {
+  /**@internal */
+  static inject() { return [RouteLoader]; }
+  /**
+   * Route loader isntance that will handle loading route config
+   * @internal
+   */
+  routeLoader: RouteLoader;
+  constructor(routeLoader: RouteLoader) {
+    this.routeLoader = routeLoader;
+  }
+  /**
+   * Run the internal to load route config of a navigation instruction to prepare for next steps in the pipeline
+   */
+  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
+    return loadNewRoute(this.routeLoader, navigationInstruction)
+      .then(next, next.cancel);
+  }
+}

--- a/src/utilities-activation.ts
+++ b/src/utilities-activation.ts
@@ -1,50 +1,15 @@
 import { Next, ViewPortComponent, ViewPortPlan, ViewPortInstruction, LifecycleArguments } from './interfaces';
 import { isNavigationCommand } from './navigation-commands';
 import { NavigationInstruction } from './navigation-instruction';
-import { activationStrategy } from './navigation-plan';
+import { activationStrategy } from './activation-strategy';
 import { Router } from './router';
-
-/**
- * A pipeline step responsible for finding and activating method `canDeactivate` on a view model of a route
- */
-export class CanDeactivatePreviousStep {
-  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
-    return processDeactivatable(navigationInstruction, 'canDeactivate', next);
-  }
-}
-
-/**
- * A pipeline step responsible for finding and activating method `canActivate` on a view model of a route
- */
-export class CanActivateNextStep {
-  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
-    return processActivatable(navigationInstruction, 'canActivate', next);
-  }
-}
-
-/**
- * A pipeline step responsible for finding and activating method `deactivate` on a view model of a route
- */
-export class DeactivatePreviousStep {
-  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
-    return processDeactivatable(navigationInstruction, 'deactivate', next, true);
-  }
-}
-
-/**
- * A pipeline step responsible for finding and activating method `activate` on a view model of a route
- */
-export class ActivateNextStep {
-  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
-    return processActivatable(navigationInstruction, 'activate', next, true);
-  }
-}
 
 /**
  * Recursively find list of deactivate-able view models
  * and invoke the either 'canDeactivate' or 'deactivate' on each
+ * @internal exported for unit testing
  */
-const processDeactivatable = (
+export const processDeactivatable = (
   navigationInstruction: NavigationInstruction,
   callbackName: 'canDeactivate' | 'deactivate',
   next: Next,
@@ -83,8 +48,9 @@ const processDeactivatable = (
 
 /**
  * Recursively find and returns a list of deactivate-able view models
+ * @internal exported for unit testing
  */
-const findDeactivatable = (
+export const findDeactivatable = (
   plan: Record<string, ViewPortPlan>,
   callbackName: string,
   list: IActivatableInfo[] = []
@@ -113,7 +79,10 @@ const findDeactivatable = (
   return list;
 };
 
-const addPreviousDeactivatable = (
+/**
+ * @internal exported for unit testing
+ */
+export const addPreviousDeactivatable = (
   component: ViewPortComponent,
   callbackName: string,
   list: IActivatableInfo[]
@@ -137,7 +106,10 @@ const addPreviousDeactivatable = (
   }
 };
 
-const processActivatable = (
+/**
+ * @internal exported for unit testing
+ */
+export const processActivatable = (
   navigationInstruction: NavigationInstruction,
   callbackName: 'canActivate' | 'activate',
   next: Next,
@@ -182,8 +154,9 @@ interface IActivatableInfo {
 
 /**
  * Find list of activatable view model and add to list (3rd parameter)
+ * @internal exported for unit testing
  */
-const findActivatable = (
+export const findActivatable = (
   navigationInstruction: NavigationInstruction,
   callbackName: 'canActivate' | 'activate',
   list: IActivatableInfo[] = [],

--- a/src/utilities-route-loading.ts
+++ b/src/utilities-route-loading.ts
@@ -2,8 +2,8 @@ import { RouteConfig, ViewPortComponent, ViewPortPlan, ViewPortInstruction } fro
 import { Redirect } from './navigation-commands';
 import { NavigationInstruction } from './navigation-instruction';
 import { _buildNavigationPlan } from './navigation-plan';
-import { Router } from './router';
-import { activationStrategy, InternalActivationStrategy } from './activation-strategy';
+import { InternalActivationStrategy } from './activation-strategy';
+import { RouteLoader } from './route-loader';
 
 /**
  * Loading plan calculated based on a navigration-instruction and a viewport plan
@@ -11,21 +11,6 @@ import { activationStrategy, InternalActivationStrategy } from './activation-str
 interface ILoadingPlan {
   viewPortPlan: ViewPortPlan;
   navigationInstruction: NavigationInstruction;
-}
-
-/**
- * Abstract class that is responsible for loading view / view model from a route config
- * The default implementation can be found in `aurelia-templating-router`
- */
-export class RouteLoader {
-  /**
-   * Load a route config based on its viewmodel / view configuration
-   */
-  // return typing: return typings used to be never
-  // as it was a throw. Changing it to Promise<any> should not cause any issues
-  loadRoute(router: Router, config: RouteConfig, navigationInstruction: NavigationInstruction): Promise<any> {
-    throw new Error('Route loaders must implement "loadRoute(router, config, navigationInstruction)".');
-  }
 }
 
 /**

--- a/src/utilities-route-loading.ts
+++ b/src/utilities-route-loading.ts
@@ -1,8 +1,9 @@
-import { Next, RouteConfig, ViewPortComponent, ViewPortPlan, ViewPortInstruction } from './interfaces';
+import { RouteConfig, ViewPortComponent, ViewPortPlan, ViewPortInstruction } from './interfaces';
 import { Redirect } from './navigation-commands';
 import { NavigationInstruction } from './navigation-instruction';
-import { activationStrategy, _buildNavigationPlan } from './navigation-plan';
+import { _buildNavigationPlan } from './navigation-plan';
 import { Router } from './router';
+import { activationStrategy, InternalActivationStrategy } from './activation-strategy';
 
 /**
  * Loading plan calculated based on a navigration-instruction and a viewport plan
@@ -24,31 +25,6 @@ export class RouteLoader {
   // as it was a throw. Changing it to Promise<any> should not cause any issues
   loadRoute(router: Router, config: RouteConfig, navigationInstruction: NavigationInstruction): Promise<any> {
     throw new Error('Route loaders must implement "loadRoute(router, config, navigationInstruction)".');
-  }
-}
-
-/**
- * A pipeline step responsible for loading a route config of a navigation instruction
- */
-export class LoadRouteStep {
-  /**@internal */
-  static inject() { return [RouteLoader]; }
-  /**
-   * Route loader isntance that will handle loading route config
-   * @internal
-   */
-  routeLoader: RouteLoader;
-
-  constructor(routeLoader: RouteLoader) {
-    this.routeLoader = routeLoader;
-  }
-
-  /**
-   * Run the internal to load route config of a navigation instruction to prepare for next steps in the pipeline
-   */
-  run(navigationInstruction: NavigationInstruction, next: Next): Promise<any> {
-    return loadNewRoute(this.routeLoader, navigationInstruction)
-      .then(next, next.cancel);
   }
 }
 
@@ -82,7 +58,7 @@ export const determineWhatToLoad = (
     let viewPortPlan = plan[viewPortName];
     let child_nav_instruction = viewPortPlan.childNavigationInstruction;
 
-    if (viewPortPlan.strategy === activationStrategy.replace) {
+    if (viewPortPlan.strategy === InternalActivationStrategy.Replace) {
       toLoad.push({ viewPortPlan, navigationInstruction } as ILoadingPlan);
 
       if (child_nav_instruction) {

--- a/test/route-loading/load-component.spec.ts
+++ b/test/route-loading/load-component.spec.ts
@@ -1,7 +1,7 @@
 import '../setup';
 import { Container } from 'aurelia-dependency-injection';
 import { NavigationInstruction, RouteConfig, Router, RouterConfiguration } from '../../src/aurelia-router';
-import { loadComponent, RouteLoader } from '../../src/route-loading';
+import { loadComponent, RouteLoader } from '../../src/utilities-route-loading';
 import {
   ViewPortComponent,
   ViewPortInstruction,

--- a/test/route-loading/load-component.spec.ts
+++ b/test/route-loading/load-component.spec.ts
@@ -1,7 +1,8 @@
 import '../setup';
 import { Container } from 'aurelia-dependency-injection';
 import { NavigationInstruction, RouteConfig, Router, RouterConfiguration } from '../../src/aurelia-router';
-import { loadComponent, RouteLoader } from '../../src/utilities-route-loading';
+import { loadComponent } from '../../src/utilities-route-loading';
+import { RouteLoader } from '../../src/route-loader';
 import {
   ViewPortComponent,
   ViewPortInstruction,

--- a/test/route-loading/load-route-step.spec.ts
+++ b/test/route-loading/load-route-step.spec.ts
@@ -1,6 +1,6 @@
 import '../setup';
 import { Container } from 'aurelia-dependency-injection';
-import { RouteLoader } from '../../src/utilities-route-loading';
+import { RouteLoader } from '../../src/route-loader';
 import { LoadRouteStep } from '../../src/step-load-route';
 import { NavigationInstruction, Next, PipelineResult, activationStrategy, RouteConfig } from '../../src/aurelia-router';
 import { createNextFn } from '../../src/next';

--- a/test/route-loading/load-route-step.spec.ts
+++ b/test/route-loading/load-route-step.spec.ts
@@ -1,6 +1,7 @@
 import '../setup';
 import { Container } from 'aurelia-dependency-injection';
-import { LoadRouteStep, RouteLoader } from '../../src/route-loading';
+import { RouteLoader } from '../../src/utilities-route-loading';
+import { LoadRouteStep } from '../../src/step-load-route';
 import { NavigationInstruction, Next, PipelineResult, activationStrategy, RouteConfig } from '../../src/aurelia-router';
 import { createNextFn } from '../../src/next';
 import { PipelineStatus } from '../../src/pipeline-status';


### PR DESCRIPTION
This PR focuses on re-organizing files and classes to make it easier to discover. Along with linting fixes and big function breakdown, such as `_buildNavigationPlan` in `navigation-plan.ts`

Another refactoring target was to have more local variables over long property chain access with verbose name, this should help greatly with minification.

After this, the focus will be fixing bug and incorporating existing PRs

@EisenbergEffect @davismj @fkleuver 

Also add an overload for `NavigationInstruction.prototype.addViewPortInstruction` to accept an options object, to open a path for future feature related to static view model. It looks like this

```ts
  /**
   * Adds a viewPort instruction. Returns the newly created instruction based on parameters
   */
  addViewPortInstruction(initOptions: ViewPortInstructionInit): /*ViewPortInstruction*/ any;
  addViewPortInstruction(viewPortName: string, strategy: ActivationStrategyType, moduleId: string, component: any): /*ViewPortInstruction*/ any;
  addViewPortInstruction(
    nameOrInitOptions: string | ViewPortInstructionInit,
    strategy?: ActivationStrategyType,
    moduleId?: string,
    component?: any
  ): /*ViewPortInstruction*/ any;
```